### PR TITLE
CORDOPLUG-240

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -57,11 +57,6 @@ dependencies {
 
   // Google cloud messaging (GCM)
   compile "com.google.android.gms:play-services-gcm:9.6.1"
-
-  // Required FIDO libraries
-  compile 'com.samsung.sds.fido.uaf.sdk:fido-client:1.5.0@aar'
-  compile 'org.fidoalliance.uaf.client.common:samsungsds-ccom:1.5.0@aar'
-  compile 'com.samsung.sds.fido.uaf.message:samsungsds-um:1.5.0'
 }
 
 afterEvaluate {


### PR DESCRIPTION
Remove unnecessary FIDO dependencies

They cause the app to crash if there is no internet connectivity
because the Guava dependency is no longer provided by the SDK.