### PR TITLE
CORDOPLUG-261

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -142,6 +142,7 @@
     <header-file src="src/ios/OneginiSDKiOS/Headers/ONGFingerprintChallenge.h"/>
     <header-file src="src/ios/OneginiSDKiOS/Headers/ONGMobileAuthRequest.h"/>
     <header-file src="src/ios/OneginiSDKiOS/Headers/ONGMobileAuthRequestDelegate.h"/>
+    <header-file src="src/ios/OneginiSDKiOS/Headers/ONGMultipartData.h"/>
     <header-file src="src/ios/OneginiSDKiOS/Headers/ONGNetworkTask.h"/>
     <header-file src="src/ios/OneginiSDKiOS/Headers/ONGPinChallenge.h"/>
     <header-file src="src/ios/OneginiSDKiOS/Headers/ONGPublicDefines.h"/>

--- a/src/ios/build.gradle
+++ b/src/ios/build.gradle
@@ -33,7 +33,7 @@ allprojects {
     mavenCentral()
 
     maven {
-      url "https://repo.onegini.com/artifactory/onegini-sdk"
+      url "https://repo.onegini.com/artifactory/public"
       credentials {
         if (project.hasProperty('artifactory_user') && project.hasProperty('artifactory_password')) {
           username artifactory_user
@@ -53,11 +53,11 @@ configurations {
 }
 
 dependencies {
-  sdk 'com.onegini.mobile.sdk.ios:libOneginiSDKiOS:6.0.0@a'
-  sdk 'com.onegini.mobile.sdk.ios:libOneginiSDKiOS:6.0.0:headers@zip'
+  sdk 'com.onegini.mobile.sdk.ios:libOneginiSDKiOS:6.1.3-SNAPSHOT@a'
+  sdk 'com.onegini.mobile.sdk.ios:libOneginiSDKiOS:6.1.3-SNAPSHOT:headers@zip'
 
-  fido 'com.onegini.mobile.sdk.ios:libOneginiSDKiOSFIDO:6.0.0@a'
-  fido 'com.onegini.mobile.sdk.ios:libOneginiSDKiOSFIDO:6.0.0:headers@zip'
+  fido 'com.onegini.mobile.sdk.ios:libOneginiSDKiOSFIDO:6.1.3-SNAPSHOT@a'
+  fido 'com.onegini.mobile.sdk.ios:libOneginiSDKiOSFIDO:6.1.3-SNAPSHOT:headers@zip'
 }
 
 task prepareTargetDirectory {

--- a/src/ios/classes/OGCDVResourceClient.m
+++ b/src/ios/classes/OGCDVResourceClient.m
@@ -35,20 +35,23 @@ int const OGCDVFetchResultHeaderLength = 4;
 
         NSString *url = options[OGCDVPluginKeyUrl];
         NSString *method = options[OGCDVPluginKeyMethod];
-        NSDictionary *params = options[OGCDVPluginKeyBody];
+        NSString *body = options[OGCDVPluginKeyBody];
         NSMutableDictionary *headers = options[OGCDVPluginKeyHeaders];
-        NSDictionary *convertedHeaders = [self convertNumbersToStringsInDictionary:headers];
         BOOL anonymous = [options[OGCDVPluginKeyAnonymous] boolValue];
 
         ONGRequestBuilder *requestBuilder = [ONGRequestBuilder builder];
+
+        if (body) {
+            [requestBuilder setBody:[body dataUsingEncoding:NSUTF8StringEncoding]];
+            BOOL contentTypeNotSet = !(headers[@"Content-Type"] || headers[@"content-type"]);
+            if (contentTypeNotSet) {
+                [headers setObject:@"application/json" forKey:@"Content-Type"];
+            }
+        }
+        NSDictionary *convertedHeaders = [self convertNumbersToStringsInDictionary:headers];
         [requestBuilder setHeaders:convertedHeaders];
         [requestBuilder setMethod:method];
         [requestBuilder setPath:url];
-
-        if (params != nil) {
-            [requestBuilder setParametersEncoding:ONGParametersEncodingJSON];
-            [requestBuilder setParameters:params];
-        }
 
         ONGResourceRequest *request = [requestBuilder build];
 

--- a/src/ios/classes/OGCDVResourceClient.m
+++ b/src/ios/classes/OGCDVResourceClient.m
@@ -43,8 +43,7 @@ int const OGCDVFetchResultHeaderLength = 4;
 
         if (body) {
             [requestBuilder setBody:[body dataUsingEncoding:NSUTF8StringEncoding]];
-            BOOL contentTypeNotSet = !(headers[@"Content-Type"] || headers[@"content-type"]);
-            if (contentTypeNotSet) {
+            if ([self isContentTypeNotSet:headers]) {
                 [headers setObject:@"application/json" forKey:@"Content-Type"];
             }
         }
@@ -65,6 +64,16 @@ int const OGCDVFetchResultHeaderLength = 4;
             }];
         }
     }];
+}
+
+- (BOOL)isContentTypeNotSet:(NSMutableDictionary *)headers {
+    NSArray *keys = [headers allKeys];
+    for (NSString *key in keys) {
+        if ([@"content-type" compare:key options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+            return NO;
+        }
+    }
+    return YES;
 }
 
 - (void)handleResponse:(ONGResourceResponse *)response withError:(NSError *)error forCallbackId:(NSString *)callbackId

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -77,6 +77,15 @@ module.exports = (function (XMLHttpRequest, TextDecoder, CustomEvent) {
       throw new TypeError("Onegini: missing 'url' argument for fetch");
     }
 
+    if (options.body && typeof options.body !== 'string') {
+      try {
+        options.body = JSON.stringify(options.body);
+      } catch (e) {
+        console.error(e);
+        throw new TypeError('Onegini: resource.fetch: options.body could not be stringified. JSON.stringify is used to transform the body to a String.');
+      }
+    }
+
     function sliceBuffer(buffer) {
       var ArrrayBuffer = require('core-js/fn/typed/array-buffer');
       buffer = ArrayBuffer.prototype.slice.call(buffer, [0, buffer.length]);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1583,6 +1583,66 @@ function sendMobileAuthRequest(type, user, callback) {
             });
       });
 
+      it('should fetch a resource with a JSON body without content-type', function (done) {
+        var body = {
+          "foo": "oof",
+          "bar": "baz"
+        };
+        onegini.resource.fetch(
+          {
+            url: 'https://onegini-msp-snapshot.test.onegini.io/resources/mirror-request',
+            method: 'POST',
+            body: body,
+            headers: {
+              'X-Test-String': 'foobar',
+              'X-Test-Int': 1337
+            }
+          },
+          function (response) {
+            expect(response).toBeDefined();
+            expect(response.body).toEqual(JSON.stringify(body));
+            expect(response.rawBody).toBeDefined();
+            expect(response.headers).toBeDefined();
+            expect(response.headers['Content-Type']).toEqual('application/json');
+            expect(response.status).toEqual(200);
+            expect(response.statusText).toBeDefined();
+            done();
+          }, function (err) {
+            expect(err).toBeUndefined();
+            fail('Error callback called, but method should have succeeded');
+          });
+      });
+
+      it('should fetch a resource with a specific body', function (done) {
+        var body = {
+          "foo": "oof",
+          "bar": "baz"
+        };
+        onegini.resource.fetch(
+          {
+            url: 'https://onegini-msp-snapshot.test.onegini.io/resources/mirror-request',
+            method: 'POST',
+            body: body,
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Test-String': 'foobar',
+              'X-Test-Int': 1337
+            }
+          },
+          function (response) {
+            expect(response).toBeDefined();
+            expect(response.body).toEqual(JSON.stringify(body));
+            expect(response.rawBody).toBeDefined();
+            expect(response.headers).toBeDefined();
+            expect(response.status).toEqual(200);
+            expect(response.statusText).toBeDefined();
+            done();
+          }, function (err) {
+            expect(err).toBeUndefined();
+            fail('Error callback called, but method should have succeeded');
+          });
+      });
+
       it('should require a url', function () {
         expect(function () {
           onegini.resource.fetch();

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1614,26 +1614,24 @@ function sendMobileAuthRequest(type, user, callback) {
       });
 
       it('should fetch a resource with a specific body', function (done) {
-        var body = {
-          "foo": "oof",
-          "bar": "baz"
-        };
+        var body = "foobar";
         onegini.resource.fetch(
           {
             url: 'https://onegini-msp-snapshot.test.onegini.io/resources/mirror-request',
             method: 'POST',
             body: body,
             headers: {
-              'Content-Type': 'application/json',
+              'Content-Type': 'text/plain',
               'X-Test-String': 'foobar',
               'X-Test-Int': 1337
             }
           },
           function (response) {
             expect(response).toBeDefined();
-            expect(response.body).toEqual(JSON.stringify(body));
+            expect(response.body).toEqual(body);
             expect(response.rawBody).toBeDefined();
             expect(response.headers).toBeDefined();
+            expect(response.headers['Content-Type']).toEqual('text/plain');
             expect(response.status).toEqual(200);
             expect(response.statusText).toBeDefined();
             done();


### PR DESCRIPTION
 Directly set the HTTP body

Instead of specifying parameters we directly set the body. In case a
body was specified without a content-type we assume that the
content-type is application/json so we don't change old behaviour.