### PR TITLE
Fix read-only property assignment

### DIFF
--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -222,7 +222,7 @@ module.exports = (function (XMLHttpRequest, TextDecoder, CustomEvent) {
     }
 
     if (listeners && listeners.length !== 0) {
-      event.target = this;
+      Object.defineProperty(event, 'target', this);
       for (let i = 0, l = listeners.length; i < l; i++) {
         listeners[i].call(this, event);
       }


### PR DESCRIPTION
When calling `onegini.fetch()` while using strict mode, the `event.target = this;` assignment causes an exception in the Cordova `callbackFromNative` function.