### PR TITLE
Change hook lifecycle

### DIFF
--- a/docs/public/topics/configuration.md
+++ b/docs/public/topics/configuration.md
@@ -5,7 +5,7 @@
 ## Configuring the Onegini SDKs
 
 The following steps describe how to configure our native Android and iOS SDKs for your platform.
-When you add a platform to your Cordova project, the Onegini Cordova Plugin will automatically try to invoke the [Onegini SDK Configurator](https://github.com/Onegini/onegini-sdk-configurator).
+When you add a platform to your Cordova project, or when you add the plugin to an existing project, the Onegini Cordova Plugin will automatically try to invoke the [Onegini SDK Configurator](https://github.com/Onegini/onegini-sdk-configurator).
 The SDK Configurator then reads the Token Server Configuration from configuration zip files you can obtain from your Token Server admin panel.
 Configuration settings not relevant to your Token Server will be read from your project's `config.xml` file.
 

--- a/hooks/configure_sdk.js
+++ b/hooks/configure_sdk.js
@@ -17,6 +17,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const spawn = require('child_process').spawn;
 
 const supportedPlatforms = ['android', 'ios'];
@@ -43,18 +44,12 @@ module.exports = function (context) {
   console.log('Configuring the Onegini SDK');
   console.log('===========================\n\n');
 
-  const platforms = context.opts.platforms;
+  // deduce the platforms based on whatever in the whitelist is currently installed
+  const platforms = supportedPlatforms.filter(platform => fs.existsSync(path.join(context.opts.projectRoot, "platforms", platform)));
 
   platforms
       .map(platform => platform.split('@')[0])
-      .filter((platform) => {
-        if (supportedPlatforms.includes(platform)) {
-          return true;
-        }
-
-        console.log(`Skipping unsupported platform: ${platform}`)
-      })
-      .forEach((platform) => {
+      .forEach(platform => {
         console.log(`Configuring the ${platform} platform`);
         console.log('--------------------------' + new Array(platform.length).join('-') + '\n');
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,8 +20,8 @@
   <name>OneginiCordovaPlugin</name>
   <description>Onegini Cordova Plugin</description>
 
-  <hook type="after_platform_add" src="hooks/configure_sdk.js"/>
   <hook type="before_plugin_install" src="hooks/resolve_dependencies.js"/>
+  <hook type="after_plugin_install" src="hooks/configure_sdk.js"/>
 
   <js-module src="dist/onegini.js" name="onegini">
     <clobbers target="onegini"/>


### PR DESCRIPTION
This PR replaces the invocation of `hooks/configure_sdk.js` from Cordova's `after_platform_add` lifecycle event with `after_plugin_install`.

The benefit of this change is that `after_platform_add` only runs after a platform is added (so you need to add the plugin _before_ adding a platform in order for the configurator to run), whereas `after_plugin_install` runs both when a platform is added after the plugin is added, and vice versa (because already installed plugins are added to the platform when a platform is added).

This also required a small change in the hook script itself, because in the `after_plugin_install` lifecycle event `context.opts.platforms` will be `undefined`.