### PR TITLE
CORDOPLUG-340 Enable Renovate on develop branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "packageRules": [
   	{
   	"packagePattern": "onegini-documentation-parent",
+    "baseBranches": [ "develop" ],
   	"enabled": "false"
   	}  	
   ]


### PR DESCRIPTION
At the moment, Renovate only looks to the `master` branch.