### PR TITLE
Cordova9 fix

### DIFF
--- a/hooks/configure_sdk.js
+++ b/hooks/configure_sdk.js
@@ -19,7 +19,6 @@
 const fs = require('fs');
 const path = require('path');
 const spawn = require('child_process').spawn;
-const q = require('q');
 
 const supportedPlatforms = ['android', 'ios'];
 const envVariables = {
@@ -40,7 +39,7 @@ module.exports = function (context) {
 
   const projectRoot = context.opts.projectRoot;
   const hasExtractedConfig = hasExtractedConfigFiles(context);
-  const deferral = q.defer();
+  const deferral = require('q').defer();
   const args = ['--cordova', '--app-dir', projectRoot];
   let platform = context.opts.plugin.platform;
 

--- a/hooks/configure_sdk.js
+++ b/hooks/configure_sdk.js
@@ -19,6 +19,7 @@
 const fs = require('fs');
 const path = require('path');
 const spawn = require('child_process').spawn;
+const q = require('q');
 
 const supportedPlatforms = ['android', 'ios'];
 const envVariables = {
@@ -39,7 +40,7 @@ module.exports = function (context) {
 
   const projectRoot = context.opts.projectRoot;
   const hasExtractedConfig = hasExtractedConfigFiles(context);
-  const deferral = context.requireCordovaModule('q').defer();
+  const deferral = q.defer();
   const args = ['--cordova', '--app-dir', projectRoot];
   let platform = context.opts.plugin.platform;
 

--- a/hooks/resolve_dependencies.js
+++ b/hooks/resolve_dependencies.js
@@ -22,6 +22,7 @@ const url = require('url');
 const https = require('https');
 const execSync = require('child_process').execSync;
 const debug = require('debug')('resolve_dependencies');
+const q = require('q');
 
 const pluginId = 'cordova-plugin-onegini';
 const extractedConfigPlugin = 'cordova-plugin-onegini-extracted-config';
@@ -48,7 +49,7 @@ let sdkDownloadPath;
 
 module.exports = function (context) {
   const platform = context.opts.plugin.platform;
-  const deferral = context.requireCordovaModule('q').defer();
+  const deferral = q.defer();
 
   // We only want to invoke the plugin for the iOS platform since it doesn't make any sense to resolve the iOS SDK dependencies when
   // you only have the Android platform installed.

--- a/hooks/resolve_dependencies.js
+++ b/hooks/resolve_dependencies.js
@@ -22,7 +22,6 @@ const url = require('url');
 const https = require('https');
 const execSync = require('child_process').execSync;
 const debug = require('debug')('resolve_dependencies');
-const q = require('q');
 
 const pluginId = 'cordova-plugin-onegini';
 const extractedConfigPlugin = 'cordova-plugin-onegini-extracted-config';
@@ -49,7 +48,7 @@ let sdkDownloadPath;
 
 module.exports = function (context) {
   const platform = context.opts.plugin.platform;
-  const deferral = q.defer();
+  const deferral = require('q').defer();
 
   // We only want to invoke the plugin for the iOS platform since it doesn't make any sense to resolve the iOS SDK dependencies when
   // you only have the Android platform installed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2328,9 +2328,8 @@
     },
     "debug": {
       "version": "4.1.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -5177,9 +5176,8 @@
     },
     "ms": {
       "version": "2.1.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -5976,6 +5974,11 @@
       "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "querystring": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "webpack": "^4.40.2",
     "webpack-cli": "^3.3.9"
   },
-  "dependencies": {}
+  "dependencies": {
+    "debug": "^4.1.1",
+    "q": "^1.5.1"
+  }
 }


### PR DESCRIPTION
I've fixed the cordova-plugin, so it can be added to cordova version `9.0.0`. The context.requireCordovaModule statement is no longer working for non-cordova modules.

Quite straightforward, non-invase fix I thing.

In addition, currently the debug module is required for `/hooks/resolve_dependencies.js`

Following errors are fixed:
```
Failed to install 'cordova-plugin-onegini': Error: Cannot find module 'debug'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/Users/martin/Development/onegini/myAuthenticatorApp/plugins/cordova-plugin-onegini/hooks/resolve_dependencies.js:24:15)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
```
```
Failed to install 'cordova-plugin-onegini': CordovaError: Using "requireCordovaModule" to load non-cordova module "q" is not supported. Instead, add this module to your dependencies and use regular "require" to load it.
    at Context.requireCordovaModule (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/hooks/Context.js:57:15)
    at module.exports (/Users/martin/Development/onegini/myAuthenticatorApp/plugins/cordova-plugin-onegini/hooks/resolve_dependencies.js:51:28)
    at runScriptViaModuleLoader (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/hooks/HooksRunner.js:181:32)
    at runScript (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/hooks/HooksRunner.js:157:16)
    at /usr/local/lib/node_modules/cordova/node_modules/cordova-lib/src/hooks/HooksRunner.js:125:20
    at process._tickCallback (internal/process/next_tick.js:68:7)
```