### PR TITLE
Uglify to Terser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-onegini",
-  "version": "6.1.1",
+  "version": "6.1.2-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1147,6 +1147,24 @@
       "integrity": "sha1-AIdQkRn/pPwKAEHR6TpBfmjLhW4=",
       "dev": true
     },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha1-2y/nJG5Tb0DZtUQqOeEX191qJOA=",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
+          "dev": true
+        }
+      }
+    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ajv/-/ajv-6.10.2.tgz",
@@ -1273,7 +1291,7 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true
     },
@@ -1285,19 +1303,19 @@
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -1306,19 +1324,19 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
@@ -1362,7 +1380,7 @@
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
@@ -1407,7 +1425,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
@@ -1485,9 +1503,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha1-qNCv1zJR7/u9X+OEp31zADwXpx8=",
+      "version": "3.7.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
       "dev": true
     },
     "bn.js": {
@@ -1590,7 +1608,7 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
@@ -1633,7 +1651,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -1643,7 +1661,7 @@
     },
     "browserify-sign": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
@@ -1678,7 +1696,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -1695,13 +1713,13 @@
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
@@ -1712,26 +1730,40 @@
       "dev": true
     },
     "cacache": {
-      "version": "12.0.3",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cacache/-/cacache-12.0.3.tgz",
-      "integrity": "sha1-vpmruk4b9d9GHNWiwQcfxDJXM5A=",
+      "version": "13.0.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cacache/-/cacache-13.0.1.tgz",
+      "integrity": "sha1-qAAMIWlwiQgvhSh6GuxuOCAkpxw=",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.5",
-        "chownr": "^1.1.1",
+        "chownr": "^1.1.2",
         "figgy-pudding": "^3.5.1",
+        "fs-minipass": "^2.0.0",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.1.15",
-        "infer-owner": "^1.0.3",
+        "graceful-fs": "^4.2.2",
+        "infer-owner": "^1.0.4",
         "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
+        "minipass": "^3.0.0",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
         "mkdirp": "^0.5.1",
         "move-concurrently": "^1.0.1",
+        "p-map": "^3.0.0",
         "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
+        "rimraf": "^2.7.1",
+        "ssri": "^7.0.0",
+        "unique-filename": "^1.1.1"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "3.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/p-map/-/p-map-3.0.0.tgz",
+          "integrity": "sha1-1wTZr4orpoTiYA2aIVmD1BQal50=",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        }
       }
     },
     "cache-base": {
@@ -1800,13 +1832,13 @@
     },
     "camelcase": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true
     },
     "camelcase-keys": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "dev": true,
       "requires": {
@@ -1859,9 +1891,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/chownr/-/chownr-1.1.2.tgz",
-      "integrity": "sha1-oY8eCyacimpdPIbrKYvrFMPde/Y=",
+      "version": "1.1.3",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha1-Qtg31SOWiNVfMDADpQgjD6ZycUI=",
       "dev": true
     },
     "chrome-trace-event": {
@@ -1912,6 +1944,12 @@
         }
       }
     },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
+      "dev": true
+    },
     "clean-webpack-plugin": {
       "version": "3.0.0",
       "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
@@ -1939,7 +1977,7 @@
     },
     "cli-truncate": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cli-truncate/-/cli-truncate-0.2.1.tgz",
       "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
       "dev": true,
       "requires": {
@@ -1955,7 +1993,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -1964,7 +2002,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -1986,7 +2024,7 @@
     },
     "cli-width": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
@@ -2048,13 +2086,13 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -2073,19 +2111,19 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI=",
+      "version": "2.20.3",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
       "dev": true
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
@@ -2097,7 +2135,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
@@ -2146,7 +2184,7 @@
     },
     "console-browserify": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
@@ -2155,7 +2193,7 @@
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
@@ -2184,7 +2222,7 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
@@ -2208,7 +2246,7 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
@@ -2295,13 +2333,13 @@
     },
     "crypto-random-string": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
@@ -2322,7 +2360,7 @@
     },
     "date-now": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
@@ -2337,13 +2375,13 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
@@ -2353,7 +2391,7 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
         }
@@ -2361,7 +2399,7 @@
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
@@ -2453,7 +2491,7 @@
     },
     "des.js": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
@@ -2495,7 +2533,7 @@
     },
     "duplexer3": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
@@ -2519,7 +2557,7 @@
     },
     "elegant-spinner": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
@@ -2546,7 +2584,7 @@
     },
     "emojis-list": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
@@ -2590,7 +2628,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -2666,7 +2704,7 @@
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
@@ -2690,7 +2728,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -2699,7 +2737,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -2725,7 +2763,7 @@
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -2822,13 +2860,13 @@
     },
     "fast-deep-equal": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
@@ -2849,7 +2887,7 @@
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
@@ -2861,7 +2899,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -2914,13 +2952,13 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -2937,6 +2975,15 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-minipass": {
+      "version": "2.0.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fs-minipass/-/fs-minipass-2.0.0.tgz",
+      "integrity": "sha1-pkFe2rAvrkuekjC8h+4uRHIAPNE=",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -2951,7 +2998,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -3592,13 +3639,13 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "github-url-from-git": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
       "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
       "dev": true
     },
@@ -3618,7 +3665,7 @@
     },
     "glob-parent": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
@@ -3628,7 +3675,7 @@
       "dependencies": {
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
@@ -3639,7 +3686,7 @@
     },
     "global-dirs": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
@@ -3689,7 +3736,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -3702,7 +3749,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -3746,7 +3793,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -3763,7 +3810,7 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
@@ -3775,7 +3822,7 @@
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -3786,7 +3833,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -3796,7 +3843,7 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -3813,7 +3860,7 @@
     },
     "hash-base": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
@@ -3833,7 +3880,7 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
@@ -3868,7 +3915,7 @@
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
@@ -3905,7 +3952,7 @@
     },
     "import-lazy": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true
     },
@@ -3921,7 +3968,7 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
@@ -3939,7 +3986,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -4009,7 +4056,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -4029,13 +4076,13 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
@@ -4059,7 +4106,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -4104,13 +4151,13 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
@@ -4147,7 +4194,7 @@
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
@@ -4167,7 +4214,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -4206,7 +4253,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
@@ -4221,7 +4268,7 @@
     },
     "is-promise": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
@@ -4269,19 +4316,19 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
@@ -4290,6 +4337,27 @@
       "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/issue-regex/-/issue-regex-2.0.0.tgz",
       "integrity": "sha1-uxgCSQOU+Ag8emeHJHy/l1Y4710=",
       "dev": true
+    },
+    "jest-worker": {
+      "version": "24.9.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/jest-worker/-/jest-worker-24.9.0.tgz",
+      "integrity": "sha1-Xb/bWy0yLphWeJgjipaXvM5ns+U=",
+      "dev": true,
+      "requires": {
+        "merge-stream": "^2.0.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "js-levenshtein": {
       "version": "1.1.6",
@@ -4565,7 +4633,7 @@
     },
     "listr-silent-renderer": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
       "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
       "dev": true
     },
@@ -4705,7 +4773,7 @@
     },
     "load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
@@ -4846,7 +4914,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -4896,19 +4964,19 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-obj": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/map-obj/-/map-obj-2.0.0.tgz",
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -4939,7 +5007,7 @@
     },
     "memory-fs": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
@@ -5076,7 +5144,7 @@
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
@@ -5103,6 +5171,50 @@
       "requires": {
         "arrify": "^1.0.1",
         "is-plain-obj": "^1.1.0"
+      }
+    },
+    "minipass": {
+      "version": "3.1.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/minipass/-/minipass-3.1.1.tgz",
+      "integrity": "sha1-dgfOd4RyoYWtbYkIKqIHD3nO3NU=",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+          "dev": true
+        }
+      }
+    },
+    "minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha1-IrgTv3Rdxu26JXa5QAIq1u3Ixhc=",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha1-gucTXX6JpQ/+ZGEKeHlTxMTLs3M=",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-pipeline": {
+      "version": "1.2.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
+      "integrity": "sha1-PctrtKVG4ylpx61xDyx5qGq7qTo=",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
       }
     },
     "mississippi": {
@@ -5146,7 +5258,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -5437,19 +5549,19 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -5460,7 +5572,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -5486,7 +5598,7 @@
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -5507,7 +5619,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
@@ -5516,7 +5628,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -5543,7 +5655,7 @@
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
@@ -5607,7 +5719,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -5754,7 +5866,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
@@ -5770,7 +5882,7 @@
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
@@ -5782,31 +5894,31 @@
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
@@ -5854,13 +5966,13 @@
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -5878,7 +5990,7 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
@@ -5896,7 +6008,7 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
@@ -5914,13 +6026,13 @@
     },
     "prr": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
@@ -5979,19 +6091,19 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "quick-lru": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/quick-lru/-/quick-lru-1.1.0.tgz",
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
@@ -6028,7 +6140,7 @@
     },
     "read-pkg": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
@@ -6144,7 +6256,7 @@
     },
     "redent": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/redent/-/redent-2.0.0.tgz",
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "dev": true,
       "requires": {
@@ -6256,7 +6368,7 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
@@ -6268,13 +6380,13 @@
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
@@ -6333,7 +6445,7 @@
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
@@ -6383,7 +6495,7 @@
     },
     "run-async": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
@@ -6401,13 +6513,13 @@
     },
     "rx-lite": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
       "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
@@ -6431,7 +6543,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -6469,7 +6581,7 @@
     },
     "semver-diff": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
@@ -6477,14 +6589,14 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha1-z8IArvd7YAxH2pu4FJyUPnmML9s=",
+      "version": "2.1.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
       "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
@@ -6513,7 +6625,7 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
@@ -6529,7 +6641,7 @@
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
@@ -6538,19 +6650,19 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
@@ -6684,7 +6796,7 @@
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
@@ -6702,9 +6814,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
+      "version": "0.5.16",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha1-CuBp5/47p1OMZMmFFeNTOerFoEI=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -6721,7 +6833,7 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
@@ -6782,17 +6894,18 @@
       "dev": true
     },
     "ssri": {
-      "version": "6.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
+      "version": "7.1.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ssri/-/ssri-7.1.0.tgz",
+      "integrity": "sha1-ksJBv23oI2W1x/tL126XVSLhKU0=",
       "dev": true,
       "requires": {
-        "figgy-pudding": "^3.5.1"
+        "figgy-pudding": "^3.5.1",
+        "minipass": "^3.1.1"
       }
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -6802,7 +6915,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -6881,13 +6994,13 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -6899,13 +7012,13 @@
     },
     "strip-indent": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-indent/-/strip-indent-2.0.0.tgz",
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
@@ -6959,7 +7072,7 @@
     },
     "term-size": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
@@ -6979,7 +7092,7 @@
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
@@ -7048,9 +7161,9 @@
       }
     },
     "terser": {
-      "version": "4.3.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/terser/-/terser-4.3.1.tgz",
-      "integrity": "sha1-CYILyzOYKZxLSNmoau/GUSfQ7WU=",
+      "version": "4.4.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/terser/-/terser-4.4.2.tgz",
+      "integrity": "sha1-RI//rQJF9Miid86JeItFi/13Bug=",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -7067,22 +7180,100 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha1-YbGOQOruW+l+dxzbsQ7RKAiIwrQ=",
+      "version": "2.2.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/terser-webpack-plugin/-/terser-webpack-plugin-2.2.2.tgz",
+      "integrity": "sha1-Km4AI3ElVkpFWtabIuCO5ZQgRzo=",
       "dev": true,
       "requires": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "cacache": "^13.0.1",
+        "find-cache-dir": "^3.1.0",
+        "jest-worker": "^24.9.0",
+        "schema-utils": "^2.6.1",
+        "serialize-javascript": "^2.1.1",
         "source-map": "^0.6.1",
-        "terser": "^4.1.2",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
+        "terser": "^4.4.2",
+        "webpack-sources": "^1.4.3"
       },
       "dependencies": {
+        "find-cache-dir": {
+          "version": "3.1.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/find-cache-dir/-/find-cache-dir-3.1.0.tgz",
+          "integrity": "sha1-mTWJSZnevvTPn2d/32RtACxM3ss=",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.0",
+            "pkg-dir": "^4.1.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/make-dir/-/make-dir-3.0.0.tgz",
+          "integrity": "sha1-G1859rknDtM/nwVMXA+EMEmJ+AE=",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "2.6.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/schema-utils/-/schema-utils-2.6.1.tgz",
+          "integrity": "sha1-63jwuUXHvPoggrNWXo2zVIAR3E8=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/source-map/-/source-map-0.6.1.tgz",
@@ -7099,7 +7290,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -7139,7 +7330,7 @@
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
@@ -7151,7 +7342,7 @@
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -7189,7 +7380,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
@@ -7199,13 +7390,13 @@
     },
     "trim-newlines": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/trim-newlines/-/trim-newlines-2.0.0.tgz",
       "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
       "dev": true
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
@@ -7217,7 +7408,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
@@ -7232,49 +7423,6 @@
       "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha1-cEaBNFxTqLIHn7bOwpSwXq0kL/U=",
-      "dev": true,
-      "requires": {
-        "commander": "~2.20.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
-        }
-      }
-    },
-    "uglifyjs-webpack-plugin": {
-      "version": "2.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz",
-      "integrity": "sha1-51vIDn8ZN/cllUybTFoeln6p0Nc=",
-      "dev": true,
-      "requires": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.6.0",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
-        }
-      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -7336,7 +7484,7 @@
     },
     "unique-string": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
@@ -7345,7 +7493,7 @@
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -7355,7 +7503,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -7366,7 +7514,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -7377,7 +7525,7 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
@@ -7441,13 +7589,13 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "requires": {
@@ -7457,7 +7605,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -7507,7 +7655,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
@@ -7582,6 +7730,63 @@
         "terser-webpack-plugin": "^1.4.1",
         "watchpack": "^1.6.0",
         "webpack-sources": "^1.4.1"
+      },
+      "dependencies": {
+        "cacache": {
+          "version": "12.0.3",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cacache/-/cacache-12.0.3.tgz",
+          "integrity": "sha1-vpmruk4b9d9GHNWiwQcfxDJXM5A=",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.5",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.3",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "ssri": {
+          "version": "6.0.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1"
+          }
+        },
+        "terser-webpack-plugin": {
+          "version": "1.4.2",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/terser-webpack-plugin/-/terser-webpack-plugin-1.4.2.tgz",
+          "integrity": "sha1-4jwNVUWH0fRzvQz2hidyDnM4kKQ=",
+          "dev": true,
+          "requires": {
+            "cacache": "^12.0.2",
+            "find-cache-dir": "^2.1.0",
+            "is-wsl": "^1.1.0",
+            "schema-utils": "^1.0.0",
+            "serialize-javascript": "^2.1.1",
+            "source-map": "^0.6.1",
+            "terser": "^4.1.2",
+            "webpack-sources": "^1.4.0",
+            "worker-farm": "^1.7.0"
+          }
+        }
       }
     },
     "webpack-cli": {
@@ -7643,7 +7848,7 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
@@ -7743,7 +7948,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -7760,7 +7965,7 @@
     },
     "xdg-basedir": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,19 +14,19 @@
       }
     },
     "@babel/core": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/core/-/core-7.6.0.tgz",
-      "integrity": "sha1-mwD3NVTt1nvryG34MD72eL49e0g=",
+      "version": "7.7.5",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/core/-/core-7.7.5.tgz",
+      "integrity": "sha1-rhMjzQNbUWApMwf1BkfoP4umL34=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.0",
-        "@babel/helpers": "^7.6.0",
-        "@babel/parser": "^7.6.0",
-        "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.0",
-        "@babel/types": "^7.6.0",
-        "convert-source-map": "^1.1.0",
+        "@babel/generator": "^7.7.4",
+        "@babel/helpers": "^7.7.4",
+        "@babel/parser": "^7.7.5",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4",
+        "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
         "lodash": "^4.17.13",
@@ -36,137 +36,146 @@
       }
     },
     "@babel/generator": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/generator/-/generator-7.6.0.tgz",
-      "integrity": "sha1-4sIe+/0yk62BmiNZtEjwAr/f2lY=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/generator/-/generator-7.7.4.tgz",
+      "integrity": "sha1-22UeKEDKmqZvMn3OwdxfX6lhE2k=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.6.0",
+        "@babel/types": "^7.7.4",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "source-map": "^0.5.0"
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
-      "integrity": "sha1-Mj053QtQ4Qx8Bsp9djjmhk2MXDI=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
+      "integrity": "sha1-uz+vHnS3S9VH6Gfkj1UfprCYts4=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
-      "integrity": "sha1-a2lijf5Ah3mODE7Zjj1Kay+9L18=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz",
+      "integrity": "sha1-X3PysoWA4iS1ub0DFGpAFdYhf18=",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-explode-assignable-expression": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.4.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
-      "integrity": "sha1-h8H4yhmtVSpzanonscH8+LH/H0M=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz",
+      "integrity": "sha1-YhuD5ZZyK1DABm+dw30yMuRhuAE=",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/helper-hoist-variables": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
+      "integrity": "sha1-bVdiNZ/TT02hUA5M/5lVtSmar1k=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.6.0"
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.5.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
-      "integrity": "sha1-PewywgRvN+CbKMk+sLED/Sol02k=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz",
+      "integrity": "sha1-KEG/kuuL2ckGhRVG/mudReFi8XY=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.5.5",
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/types": "^7.7.4",
         "lodash": "^4.17.13"
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
-      "integrity": "sha1-U3+hP28WdN90WwwA7I/k6ZaByPY=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
+      "integrity": "sha1-+nAIeOAI2F3FG6Q+n7g1zd/gXIQ=",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-      "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+      "integrity": "sha1-q24EHnE11DbY8KPsoV3ltno0Gi4=",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "^7.7.4",
+        "@babel/template": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-      "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+      "integrity": "sha1-y0Y0jS+ICOYy8KsEgXITDmNgBfA=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.4.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
-      "integrity": "sha1-Api18lyMCcUxAtUqxKmPdz6yhQo=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz",
+      "integrity": "sha1-YSOE49gj/fqvn84xVQ/l1NsPPRI=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4"
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.5.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
-      "integrity": "sha1-H7W47ERTqTxDnun+Ou6kqEt2tZA=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
+      "integrity": "sha1-NWQ44lad9zIagyZkTUt5DSEiy3Q=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.5.5"
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
-      "integrity": "sha1-lggbcRHkhtpNLNlxrRpP4hbMLj0=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
+      "integrity": "sha1-5aklKfiIi/MZpjdqv70c68SRrZE=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.5.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
-      "integrity": "sha1-+E/4oJA43Lyh/UNVZhpQCTcWW0o=",
+      "version": "7.7.5",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.7.5.tgz",
+      "integrity": "sha1-0ETaf/2R7JZ9slzWdI9wS2skSDU=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/template": "^7.4.4",
-        "@babel/types": "^7.5.5",
+        "@babel/helper-module-imports": "^7.7.4",
+        "@babel/helper-simple-access": "^7.7.4",
+        "@babel/helper-split-export-declaration": "^7.7.4",
+        "@babel/template": "^7.7.4",
+        "@babel/types": "^7.7.4",
         "lodash": "^4.17.13"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-      "integrity": "sha1-opIMVwKwc8Fd5REGIAqoytIEl9U=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
+      "integrity": "sha1-A0rzE3DSmVJCqk30AsO3eUstzfI=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -185,70 +194,70 @@
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
-      "integrity": "sha1-Nh2AghtvONp1vT8HheziCojF/n8=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
+      "integrity": "sha1-xowkBzUNmvDgYe1nJq+0//FtAjQ=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-wrap-function": "^7.1.0",
-        "@babel/template": "^7.1.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-annotate-as-pure": "^7.7.4",
+        "@babel/helper-wrap-function": "^7.7.4",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.5.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
-      "integrity": "sha1-+EzkPfAxIi0rrQaNJibLV5nDS8I=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
+      "integrity": "sha1-PIgaamp1cSdactguYQcSbsnizdI=",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.5.5",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.5.5",
-        "@babel/types": "^7.5.5"
+        "@babel/helper-member-expression-to-functions": "^7.7.4",
+        "@babel/helper-optimise-call-expression": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
-      "integrity": "sha1-Ze65VMjCRb6qToWdphiPOdceWFw=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
+      "integrity": "sha1-oWmgrbG19BjPwZ8iWGsuv1ipopQ=",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/template": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.4.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-      "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+      "integrity": "sha1-Vykq9gRDxKNiLPdAQN3Cjmgzb9g=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4"
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-wrap-function": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
-      "integrity": "sha1-xOABJEV2nigVtVKW6tQ6lYVJ9vo=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
+      "integrity": "sha1-N6t/7VFQ4i2dcmboMAcsDN2Lqs4=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/template": "^7.1.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.2.0"
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helpers": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helpers/-/helpers-7.6.0.tgz",
-      "integrity": "sha1-IZYdFsajw6tZcyXDTEZcCIfTHG4=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/helpers/-/helpers-7.7.4.tgz",
+      "integrity": "sha1-YsIVuebHEtrcFamg3Kt2ySqUAwI=",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.0",
-        "@babel/types": "^7.6.0"
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/highlight": {
@@ -263,151 +272,159 @@
       }
     },
     "@babel/parser": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/parser/-/parser-7.6.0.tgz",
-      "integrity": "sha1-PgXQZHQyqDJsso0N4DiVrlpX85s=",
+      "version": "7.7.5",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/parser/-/parser-7.7.5.tgz",
+      "integrity": "sha1-y/RTIWGawS2DNj/PnJS7Z/pkbXE=",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
-      "integrity": "sha1-somzBmadzkrSCwJSiJoVdoydQX4=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
+      "integrity": "sha1-A1HFrAqeknhF//1bgq9HaUe3zm0=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.1.0",
-        "@babel/plugin-syntax-async-generators": "^7.2.0"
+        "@babel/helper-remap-async-to-generator": "^7.7.4",
+        "@babel/plugin-syntax-async-generators": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.5.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
-      "integrity": "sha1-5TIgLbSDhyNpGxCme4zlCeOXxQY=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz",
+      "integrity": "sha1-3eZKfxJ2kXWMv+1s9w3g+lh51S0=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.2.0"
+        "@babel/plugin-syntax-dynamic-import": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-json-strings": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
-      "integrity": "sha1-Vo7MRGxhSK5rJn8CVREwiR4p8xc=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
+      "integrity": "sha1-dwCmv9p3HY3IGXMknqxBbGtMaX0=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-json-strings": "^7.2.0"
+        "@babel/plugin-syntax-json-strings": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.5.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
-      "integrity": "sha1-YZOXRPcbp2o65Gte6hilTBbSLlg=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
+      "integrity": "sha1-zFeEmJSlx3QhQXjIq2T2M07Ir3E=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+        "@babel/plugin-syntax-object-rest-spread": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
-      "integrity": "sha1-E12B7baKCB5V5W7EhUHs6AZcOPU=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
+      "integrity": "sha1-7CHorrCexnEbwKOcpJUgq+4d43k=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+        "@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.4.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
-      "integrity": "sha1-UB/9mCbAuR2iJpByByKsfLHKnHg=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.4.tgz",
+      "integrity": "sha1-fCOcyvCUcNvh1FPVAFdGDoRRfrs=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.4.4",
-        "regexpu-core": "^4.5.4"
+        "@babel/helper-create-regexp-features-plugin": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-async-generators": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
-      "integrity": "sha1-aeHw2zTG9aDPfiszI78VmnbIy38=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
+      "integrity": "sha1-MxqvMQoQyAxEpmsji25JEyvTyIk=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
-      "integrity": "sha1-acFZ/69JmBIhYa2OvF5tH1XfhhI=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
+      "integrity": "sha1-Kco7RBWr/kpew4HpA4Yq0aVMOuw=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-json-strings": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
-      "integrity": "sha1-cr0T9v/h0lk4Ep0qGGsR/WKVFHA=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
+      "integrity": "sha1-huY/fS4i+eJxKaxOg+qYmjguhsw=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
-      "integrity": "sha1-O3o+czUQxX6CC5FCpleayLDfrS4=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
+      "integrity": "sha1-R88iDRnW0NexVDBHAfRo/BzG/0Y=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
-      "integrity": "sha1-qUAT1u2okI3+akd+f57ahWVuz1w=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
+      "integrity": "sha1-o+OPWfS2IzhntKktyw7gWywzSqY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.4.tgz",
+      "integrity": "sha1-vX2Pp7n+55OjbkAn/W3RqjL5Rto=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
-      "integrity": "sha1-mur75Nb/xlY7+Pg3IJFijwB3lVA=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
+      "integrity": "sha1-djCb1Xit3YruOzedgJyAIwWpihI=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.5.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
-      "integrity": "sha1-iaOEigFmYjtbxIEWS1k2q5R+iH4=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
+      "integrity": "sha1-aUy+rm1hOjTvApJxP6QvtFxEcLo=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-module-imports": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.1.0"
+        "@babel/helper-remap-async-to-generator": "^7.7.4"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
-      "integrity": "sha1-XTzBHo1d3XUqpkyRSNDbbLef0ZA=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
+      "integrity": "sha1-0NnVwmnHjq6nYies4hS40B5Ng3s=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.0.tgz",
-      "integrity": "sha1-xJ4hIoxLvUBoo1Zn5tlRx1Q5sdw=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
+      "integrity": "sha1-IAqtDc1ruANy+U2eYo6gYsWL8iQ=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -415,250 +432,249 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.5.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
-      "integrity": "sha1-0JQpnZvWgKFKKg7a44MFrWD7Tek=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz",
+      "integrity": "sha1-ySwUvgoTmeFd9yZnBnqPUQyUAOw=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.5.5",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-annotate-as-pure": "^7.7.4",
+        "@babel/helper-define-map": "^7.7.4",
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/helper-optimise-call-expression": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.5.5",
-        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/helper-replace-supers": "^7.7.4",
+        "@babel/helper-split-export-declaration": "^7.7.4",
         "globals": "^11.1.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
-      "integrity": "sha1-g6ffamWIZbHI9kHVEMbzryICFto=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz",
+      "integrity": "sha1-6FbBYo0yOP/hLWaOtCVZ95qBkQ0=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
-      "integrity": "sha1-RLvgi1f0SACU1X2f+82W0wkHW6Y=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz",
+      "integrity": "sha1-K3E3KeUFShE1CXtqZ9obb+h4kmc=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.4.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
-      "integrity": "sha1-NhoUi8lRREMSxpRG127R6o5EUMM=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.4.tgz",
+      "integrity": "sha1-98zaYRGMW3olmactXjIQiEoCHpY=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.4.4",
-        "regexpu-core": "^4.5.4"
+        "@babel/helper-create-regexp-features-plugin": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.5.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
-      "integrity": "sha1-xdv1EGv4TN9pEiLAl0wSsd+TGFM=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
+      "integrity": "sha1-PSFzGkLj9ZinODUpndAWnDuQrJE=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
-      "integrity": "sha1-pjhoKJ5bQAf3BU1GSRr1FDV2YAg=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
+      "integrity": "sha1-3TDAGR46G6GbzH44m9/dwHKdXbk=",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.4.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
-      "integrity": "sha1-Amf8c14kyAi6FzhmxsTRRA/DxVY=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz",
+      "integrity": "sha1-JIgA46XlB7HxA9i0ypmOd8Y5Mrw=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.4.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
-      "integrity": "sha1-4UNhFquwYQwiWQlISHVKxSMJIq0=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz",
+      "integrity": "sha1-dabTMD1Q22OP+LU4XRJFHIZQJbE=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-function-name": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
-      "integrity": "sha1-aQNT6B+SZ9rU/Yz9d+r6hqulPqE=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz",
+      "integrity": "sha1-J/6H0rUBeipaNNHEGmufamJiZD4=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-member-expression-literals": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
-      "integrity": "sha1-+hCqXFiiy2r88sn/qMtNiz1Imi0=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz",
+      "integrity": "sha1-ruEn8vMzn8NM5eMFXX/796om8Zo=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.5.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
-      "integrity": "sha1-7wBDXUbaCllhqnKKHS7P8GPk+5E=",
+      "version": "7.7.5",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.5.tgz",
+      "integrity": "sha1-OeD7cXIktZR1swZAK7ju2rAecpw=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-module-transforms": "^7.7.5",
         "@babel/helper-plugin-utils": "^7.0.0",
         "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
-      "integrity": "sha1-Od/pV95EIERfH8+ItoouSqRRVIY=",
+      "version": "7.7.5",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz",
+      "integrity": "sha1-HSf16wvPdUPndJUOWy+nguY3s0U=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.4.4",
+        "@babel/helper-module-transforms": "^7.7.5",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0",
+        "@babel/helper-simple-access": "^7.7.4",
         "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.5.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
-      "integrity": "sha1-51JmoT75QgLbKgYgl3dW9R1S0kk=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
+      "integrity": "sha1-zZgVIznT52Pf6Di31Cc+2vUguzA=",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.4.4",
+        "@babel/helper-hoist-variables": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0",
         "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-modules-umd": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
-      "integrity": "sha1-dnjOdRafCHe46yI1U4wHQmjdAa4=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
+      "integrity": "sha1-ECfDVaEY3gqun+4ArXgTxYTZBh8=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-module-transforms": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.0.tgz",
-      "integrity": "sha1-Hm5mMJeBO7T1PULfB1DPKK07s/E=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz",
+      "integrity": "sha1-+zvMTuQZjnOFgFAHNz1rb0LJgiA=",
       "dev": true,
       "requires": {
-        "regexp-tree": "^0.1.13"
+        "@babel/helper-create-regexp-features-plugin": "^7.7.4"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.4.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
-      "integrity": "sha1-GNEgQ4sMye6VpH8scryXaPvtYKU=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
+      "integrity": "sha1-SgdT0tYGOUN74HtZKp5Y7gByAWc=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.5.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
-      "integrity": "sha1-xwAh34NAc8ZethO4Z5zEo4HRqfk=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
+      "integrity": "sha1-SEiJN6LVhsAUhFG/Ua+dfdpWcmI=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.5.5"
+        "@babel/helper-replace-supers": "^7.7.4"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.4.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
-      "integrity": "sha1-dVbPA/MYvScZ/kySLS2Ai+VXHhY=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.4.tgz",
+      "integrity": "sha1-2kVVyX85tRrAidMcc4DwO8pAdc4=",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "^7.4.4",
-        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-call-delegate": "^7.7.4",
+        "@babel/helper-get-function-arity": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-property-literals": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
-      "integrity": "sha1-A+M/ZT9bJcTrVyyYuUhQVbOJ6QU=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz",
+      "integrity": "sha1-I4jWUF74myZhA/RQ+RZ+a9c/mMI=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.4.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
-      "integrity": "sha1-Yp3IJRLFXO4BNB+ye9/LIQNUaA8=",
+      "version": "7.7.5",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.5.tgz",
+      "integrity": "sha1-OodX7hongPOQ6J8kYGXs9Zwm/Ok=",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.14.0"
       }
     },
     "@babel/plugin-transform-reserved-words": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
-      "integrity": "sha1-R5Kvh8mYpJNnWX0H/t8CY20uFjQ=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.7.4.tgz",
+      "integrity": "sha1-anzxI60XW7XGmuyPbwdwOH7T8es=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.0.tgz",
-      "integrity": "sha1-haPM5AKyhYYTjjaPziCrMBm5cT4=",
+      "version": "7.7.6",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.6.tgz",
+      "integrity": "sha1-TytUjIiSL7mOwcJCr9RzPuPhL2E=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-module-imports": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0",
         "resolve": "^1.8.1",
         "semver": "^5.5.1"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
-      "integrity": "sha1-YzOu4vjW7n4oYVRXKYk0o7RhmPA=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz",
+      "integrity": "sha1-dKCpsvbWemhMb7/V8EWOt7qZiR4=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.2.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
-      "integrity": "sha1-MQOpq+IvdCttQG7NPNSbd0kZtAY=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz",
+      "integrity": "sha1-qmc7NW/mt+cNabbjOhf+9kEAhXg=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
-      "integrity": "sha1-oeRUtZlVYKnB4NU338FQYf0mh+E=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz",
+      "integrity": "sha1-/7aMBQkMMHMgdrEoXcFAG0BKEjw=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -666,143 +682,135 @@
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.4.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
-      "integrity": "sha1-nSj+p7vOY3+3YSoHUJidgyHUvLA=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz",
+      "integrity": "sha1-HrZBFzbdP+h9vSDMZmjlEhwX1gQ=",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-annotate-as-pure": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
-      "integrity": "sha1-EX0rzsL79ktLWdH5gZiUaC0p8rI=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
+      "integrity": "sha1-MXRiYhTy1t4yKILkmKOOg3GyFA4=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.4.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
-      "integrity": "sha1-q0Y0u08U02cov1l4Mis1WHeHlw8=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz",
+      "integrity": "sha1-o8D2WxF8TIHFtkhPKl57lTRrg64=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.4.4",
-        "regexpu-core": "^4.5.4"
+        "@babel/helper-create-regexp-features-plugin": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/preset-env": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/preset-env/-/preset-env-7.6.0.tgz",
-      "integrity": "sha1-quQUHFBhALsr+qSsKlwSs5VhnlA=",
+      "version": "7.7.6",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/preset-env/-/preset-env-7.7.6.tgz",
+      "integrity": "sha1-OaxgBCe7uU7sayeVPx36HWTUV7I=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-module-imports": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-        "@babel/plugin-proposal-dynamic-import": "^7.5.0",
-        "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
-        "@babel/plugin-syntax-async-generators": "^7.2.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-        "@babel/plugin-syntax-json-strings": "^7.2.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.5.0",
-        "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.6.0",
-        "@babel/plugin-transform-classes": "^7.5.5",
-        "@babel/plugin-transform-computed-properties": "^7.2.0",
-        "@babel/plugin-transform-destructuring": "^7.6.0",
-        "@babel/plugin-transform-dotall-regex": "^7.4.4",
-        "@babel/plugin-transform-duplicate-keys": "^7.5.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-        "@babel/plugin-transform-for-of": "^7.4.4",
-        "@babel/plugin-transform-function-name": "^7.4.4",
-        "@babel/plugin-transform-literals": "^7.2.0",
-        "@babel/plugin-transform-member-expression-literals": "^7.2.0",
-        "@babel/plugin-transform-modules-amd": "^7.5.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.6.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.5.0",
-        "@babel/plugin-transform-modules-umd": "^7.2.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.0",
-        "@babel/plugin-transform-new-target": "^7.4.4",
-        "@babel/plugin-transform-object-super": "^7.5.5",
-        "@babel/plugin-transform-parameters": "^7.4.4",
-        "@babel/plugin-transform-property-literals": "^7.2.0",
-        "@babel/plugin-transform-regenerator": "^7.4.5",
-        "@babel/plugin-transform-reserved-words": "^7.2.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.2.0",
-        "@babel/plugin-transform-spread": "^7.2.0",
-        "@babel/plugin-transform-sticky-regex": "^7.2.0",
-        "@babel/plugin-transform-template-literals": "^7.4.4",
-        "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-        "@babel/plugin-transform-unicode-regex": "^7.4.4",
-        "@babel/types": "^7.6.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.7.4",
+        "@babel/plugin-proposal-dynamic-import": "^7.7.4",
+        "@babel/plugin-proposal-json-strings": "^7.7.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.7.4",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.7.4",
+        "@babel/plugin-syntax-async-generators": "^7.7.4",
+        "@babel/plugin-syntax-dynamic-import": "^7.7.4",
+        "@babel/plugin-syntax-json-strings": "^7.7.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.7.4",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
+        "@babel/plugin-syntax-top-level-await": "^7.7.4",
+        "@babel/plugin-transform-arrow-functions": "^7.7.4",
+        "@babel/plugin-transform-async-to-generator": "^7.7.4",
+        "@babel/plugin-transform-block-scoped-functions": "^7.7.4",
+        "@babel/plugin-transform-block-scoping": "^7.7.4",
+        "@babel/plugin-transform-classes": "^7.7.4",
+        "@babel/plugin-transform-computed-properties": "^7.7.4",
+        "@babel/plugin-transform-destructuring": "^7.7.4",
+        "@babel/plugin-transform-dotall-regex": "^7.7.4",
+        "@babel/plugin-transform-duplicate-keys": "^7.7.4",
+        "@babel/plugin-transform-exponentiation-operator": "^7.7.4",
+        "@babel/plugin-transform-for-of": "^7.7.4",
+        "@babel/plugin-transform-function-name": "^7.7.4",
+        "@babel/plugin-transform-literals": "^7.7.4",
+        "@babel/plugin-transform-member-expression-literals": "^7.7.4",
+        "@babel/plugin-transform-modules-amd": "^7.7.5",
+        "@babel/plugin-transform-modules-commonjs": "^7.7.5",
+        "@babel/plugin-transform-modules-systemjs": "^7.7.4",
+        "@babel/plugin-transform-modules-umd": "^7.7.4",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
+        "@babel/plugin-transform-new-target": "^7.7.4",
+        "@babel/plugin-transform-object-super": "^7.7.4",
+        "@babel/plugin-transform-parameters": "^7.7.4",
+        "@babel/plugin-transform-property-literals": "^7.7.4",
+        "@babel/plugin-transform-regenerator": "^7.7.5",
+        "@babel/plugin-transform-reserved-words": "^7.7.4",
+        "@babel/plugin-transform-shorthand-properties": "^7.7.4",
+        "@babel/plugin-transform-spread": "^7.7.4",
+        "@babel/plugin-transform-sticky-regex": "^7.7.4",
+        "@babel/plugin-transform-template-literals": "^7.7.4",
+        "@babel/plugin-transform-typeof-symbol": "^7.7.4",
+        "@babel/plugin-transform-unicode-regex": "^7.7.4",
+        "@babel/types": "^7.7.4",
         "browserslist": "^4.6.0",
-        "core-js-compat": "^3.1.1",
+        "core-js-compat": "^3.4.7",
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.5.0"
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/runtime-corejs2/-/runtime-corejs2-7.6.0.tgz",
-      "integrity": "sha1-b803wlgAcIF9YvIZ25f2fib1D5w=",
+      "version": "7.7.6",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/runtime-corejs2/-/runtime-corejs2-7.7.6.tgz",
+      "integrity": "sha1-ULfNTquSm0y2YWfEly016s6qEks=",
       "dev": true,
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha1-a0shRiDINBUuF5Mjcn/Bl0GwhPI=",
-          "dev": true
-        }
       }
     },
     "@babel/template": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/template/-/template-7.6.0.tgz",
-      "integrity": "sha1-fwFZx/UBIjDa1kzKQuyb21yVNuY=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/template/-/template-7.7.4.tgz",
+      "integrity": "sha1-Qop9nuz/4n3qwKmOI7+ONnXSp3s=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.6.0",
-        "@babel/types": "^7.6.0"
+        "@babel/parser": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/traverse/-/traverse-7.6.0.tgz",
-      "integrity": "sha1-OJOR1RD3m+fOLd1nF75m0/7UtRY=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/traverse/-/traverse-7.7.4.tgz",
+      "integrity": "sha1-nB58YPtnn+T8+qQlAIMzM8IFhVg=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.0",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.6.0",
-        "@babel/types": "^7.6.0",
+        "@babel/generator": "^7.7.4",
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/helper-split-export-declaration": "^7.7.4",
+        "@babel/parser": "^7.7.4",
+        "@babel/types": "^7.7.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
       }
     },
     "@babel/types": {
-      "version": "7.6.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/types/-/types-7.6.1.tgz",
-      "integrity": "sha1-U6vzMIrdOsKiiE1TkVHFfEs6xkg=",
+      "version": "7.7.4",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@babel/types/-/types-7.7.4.tgz",
+      "integrity": "sha1-UWVw1TnkTd8wjAdWnCWP+U/ekZM=",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -846,6 +854,12 @@
       "version": "1.3.1",
       "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha1-M2utwb7sudrMOL6izzKt9ieoQho=",
+      "dev": true
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA=",
       "dev": true
     },
     "@types/events": {
@@ -1142,9 +1156,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.3.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/acorn/-/acorn-6.3.0.tgz",
-      "integrity": "sha1-AIdQkRn/pPwKAEHR6TpBfmjLhW4=",
+      "version": "6.4.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/acorn/-/acorn-6.4.0.tgz",
+      "integrity": "sha1-tlnS/7r6JLr12xzbsslKmD7NJ4Q=",
       "dev": true
     },
     "aggregate-error": {
@@ -1206,7 +1220,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -1224,18 +1238,18 @@
       }
     },
     "ansi-escapes": {
-      "version": "4.2.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
-      "integrity": "sha1-TczbhGw+7hD21k3qZic+q5DDcig=",
+      "version": "4.3.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+      "integrity": "sha1-pM4rM9ayFLeVDYWVwhLxKsnMVp0=",
       "dev": true,
       "requires": {
-        "type-fest": "^0.5.2"
+        "type-fest": "^0.8.1"
       }
     },
     "ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+      "version": "5.0.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
       "dev": true
     },
     "ansi-styles": {
@@ -1248,9 +1262,9 @@
       }
     },
     "any-observable": {
-      "version": "0.4.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/any-observable/-/any-observable-0.4.0.tgz",
-      "integrity": "sha1-XQRY402i7mFIwe0Urrv1dci0dDM=",
+      "version": "0.5.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/any-observable/-/any-observable-0.5.0.tgz",
+      "integrity": "sha1-LcavA4K2fP0aSeH2XlFRltTjLTg=",
       "dev": true
     },
     "anymatch": {
@@ -1265,7 +1279,7 @@
       "dependencies": {
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/normalize-path/-/normalize-path-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
@@ -1291,7 +1305,7 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true
     },
@@ -1303,19 +1317,19 @@
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -1324,19 +1338,19 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
@@ -1363,13 +1377,13 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1380,7 +1394,7 @@
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
@@ -1425,7 +1439,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
@@ -1446,7 +1460,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -1503,9 +1517,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
+      "version": "3.5.5",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha1-qNCv1zJR7/u9X+OEp31zADwXpx8=",
       "dev": true
     },
     "bn.js": {
@@ -1544,7 +1558,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -1597,7 +1611,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -1608,7 +1622,7 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
@@ -1651,7 +1665,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -1661,7 +1675,7 @@
     },
     "browserify-sign": {
       "version": "4.0.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
@@ -1684,20 +1698,20 @@
       }
     },
     "browserslist": {
-      "version": "4.7.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/browserslist/-/browserslist-4.7.0.tgz",
-      "integrity": "sha1-nuiSJf/AfbA0CfL+5STcgidFihc=",
+      "version": "4.8.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/browserslist/-/browserslist-4.8.2.tgz",
+      "integrity": "sha1-tFcgrV+8hxO3JTwgdm9wHJppQok=",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000989",
-        "electron-to-chromium": "^1.3.247",
-        "node-releases": "^1.1.29"
+        "caniuse-lite": "^1.0.30001015",
+        "electron-to-chromium": "^1.3.322",
+        "node-releases": "^1.1.42"
       }
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -1713,57 +1727,43 @@
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
     "builtins": {
       "version": "1.0.3",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/builtins/-/builtins-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
     "cacache": {
-      "version": "13.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cacache/-/cacache-13.0.1.tgz",
-      "integrity": "sha1-qAAMIWlwiQgvhSh6GuxuOCAkpxw=",
+      "version": "12.0.3",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cacache/-/cacache-12.0.3.tgz",
+      "integrity": "sha1-vpmruk4b9d9GHNWiwQcfxDJXM5A=",
       "dev": true,
       "requires": {
-        "chownr": "^1.1.2",
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
         "figgy-pudding": "^3.5.1",
-        "fs-minipass": "^2.0.0",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.2",
-        "infer-owner": "^1.0.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
         "lru-cache": "^5.1.1",
-        "minipass": "^3.0.0",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.2",
+        "mississippi": "^3.0.0",
         "mkdirp": "^0.5.1",
         "move-concurrently": "^1.0.1",
-        "p-map": "^3.0.0",
         "promise-inflight": "^1.0.1",
-        "rimraf": "^2.7.1",
-        "ssri": "^7.0.0",
-        "unique-filename": "^1.1.1"
-      },
-      "dependencies": {
-        "p-map": {
-          "version": "3.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/p-map/-/p-map-3.0.0.tgz",
-          "integrity": "sha1-1wTZr4orpoTiYA2aIVmD1BQal50=",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
-        }
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
       }
     },
     "cache-base": {
@@ -1808,7 +1808,7 @@
     },
     "caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
@@ -1817,7 +1817,7 @@
     },
     "caller-path": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/caller-path/-/caller-path-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
@@ -1826,19 +1826,19 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
     "camelcase": {
       "version": "4.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/camelcase/-/camelcase-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true
     },
     "camelcase-keys": {
       "version": "4.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "dev": true,
       "requires": {
@@ -1848,9 +1848,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000989",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-      "integrity": "sha1-uRk+KTzPfkQmxSRRNLjypWwKxLk=",
+      "version": "1.0.30001015",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+      "integrity": "sha1-Fafd9mq6eGpx2ZYmvI8rkcbw9fA=",
       "dev": true
     },
     "chalk": {
@@ -1891,9 +1891,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha1-Qtg31SOWiNVfMDADpQgjD6ZycUI=",
+      "version": "1.1.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/chownr/-/chownr-1.1.2.tgz",
+      "integrity": "sha1-oY8eCyacimpdPIbrKYvrFMPde/Y=",
       "dev": true
     },
     "chrome-trace-event": {
@@ -1935,7 +1935,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -1977,7 +1977,7 @@
     },
     "cli-truncate": {
       "version": "0.2.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
       "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
       "dev": true,
       "requires": {
@@ -1987,13 +1987,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -2002,7 +2002,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -2013,7 +2013,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2024,7 +2024,7 @@
     },
     "cli-width": {
       "version": "2.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cli-width/-/cli-width-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
@@ -2047,7 +2047,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -2077,7 +2077,7 @@
     },
     "clone-response": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/clone-response/-/clone-response-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
@@ -2086,13 +2086,13 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -2111,19 +2111,19 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+      "version": "2.20.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI=",
       "dev": true
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
@@ -2135,7 +2135,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
@@ -2176,31 +2176,28 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
       }
     },
     "console-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/console-browserify/-/console-browserify-1.1.0.tgz",
-      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true,
-      "requires": {
-        "date-now": "^0.1.4"
-      }
+      "version": "1.2.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
+      "version": "1.7.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -2222,17 +2219,23 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js": {
+      "version": "2.6.11",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha1-OIMUafmSK97Y7iHJ3EaYXgOZMIw=",
+      "dev": true
+    },
     "core-js-compat": {
-      "version": "3.2.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/core-js-compat/-/core-js-compat-3.2.1.tgz",
-      "integrity": "sha1-DL28LjhujgDTuF3IHISO/+xbgVA=",
+      "version": "3.4.8",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/core-js-compat/-/core-js-compat-3.4.8.tgz",
+      "integrity": "sha1-9y5qTtdkN+pxCSj0RhX5JqgWB9U=",
       "dev": true,
       "requires": {
-        "browserslist": "^4.6.6",
+        "browserslist": "^4.8.2",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -2246,7 +2249,7 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
@@ -2300,16 +2303,14 @@
       }
     },
     "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+      "version": "7.0.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cross-spawn/-/cross-spawn-7.0.1.tgz",
+      "integrity": "sha1-CrVihuD3wk4VPQTMKqAn5DqaXRQ=",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
       }
     },
     "crypto-browserify": {
@@ -2333,13 +2334,13 @@
     },
     "crypto-random-string": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
@@ -2348,7 +2349,7 @@
     },
     "cyclist": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cyclist/-/cyclist-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
@@ -2356,12 +2357,6 @@
       "version": "1.30.1",
       "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha1-LnG/CxGRU9u0zE6I2epaz7UNwFw=",
-      "dev": true
-    },
-    "date-now": {
-      "version": "0.1.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/date-now/-/date-now-0.1.4.tgz",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "debug": {
@@ -2375,13 +2370,13 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
@@ -2391,7 +2386,7 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
         }
@@ -2399,13 +2394,13 @@
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "decompress-response": {
       "version": "3.3.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/decompress-response/-/decompress-response-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
@@ -2419,9 +2414,9 @@
       "dev": true
     },
     "defer-to-connect": {
-      "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-      "integrity": "sha1-S651ijFLA0rjOQK1qsJajdaoYz4=",
+      "version": "1.1.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
+      "integrity": "sha1-iK5pS5P2e4GBWiyMdprvZXSsjy8=",
       "dev": true
     },
     "define-properties": {
@@ -2490,9 +2485,9 @@
       }
     },
     "des.js": {
-      "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/des.js/-/des.js-1.0.0.tgz",
-      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "version": "1.0.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -2501,7 +2496,7 @@
     },
     "detect-file": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/detect-file/-/detect-file-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
@@ -2533,7 +2528,7 @@
     },
     "duplexer3": {
       "version": "0.1.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/duplexer3/-/duplexer3-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
@@ -2550,21 +2545,21 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.260",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/electron-to-chromium/-/electron-to-chromium-1.3.260.tgz",
-      "integrity": "sha1-/9aGtIELqw4aQo569fCMIf58H6I=",
+      "version": "1.3.322",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+      "integrity": "sha1-pvfhx5AlwrBYOOjjRPbonrgyE6g=",
       "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/elliptic/-/elliptic-6.5.1.tgz",
-      "integrity": "sha1-w4D1+Qm/G5tEKNAozRjTsO/WtSs=",
+      "version": "6.5.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/elliptic/-/elliptic-6.5.2.tgz",
+      "integrity": "sha1-BcVnjXFzwEnYykM1UiJKSV0ON2I=",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -2584,7 +2579,7 @@
     },
     "emojis-list": {
       "version": "2.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/emojis-list/-/emojis-list-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
@@ -2598,14 +2593,26 @@
       }
     },
     "enhanced-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-      "integrity": "sha1-Qcfgv9/nSsH/4eV61qXGyfN0Kn8=",
+      "version": "4.1.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
+      "integrity": "sha1-KTfiuAZs0P584JkKmPDXGjUYn2Y=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
+        "memory-fs": "^0.5.0",
         "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha1-MkwBKIuIZSlm0WHbd4OHIIRajjw=",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        }
       }
     },
     "errno": {
@@ -2628,7 +2635,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -2686,16 +2693,17 @@
       }
     },
     "execa": {
-      "version": "2.0.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/execa/-/execa-2.0.4.tgz",
-      "integrity": "sha1-L1zFicgdsxZihicATqTje5M5HY4=",
+      "version": "3.4.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/execa/-/execa-3.4.0.tgz",
+      "integrity": "sha1-wI7UVQ72XYWPrCaf/IVyRG8364k=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.5",
+        "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
         "is-stream": "^2.0.0",
         "merge-stream": "^2.0.0",
-        "npm-run-path": "^3.0.0",
+        "npm-run-path": "^4.0.0",
         "onetime": "^5.1.0",
         "p-finally": "^2.0.0",
         "signal-exit": "^3.0.2",
@@ -2704,7 +2712,7 @@
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
@@ -2728,7 +2736,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -2737,7 +2745,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -2746,7 +2754,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -2754,7 +2762,7 @@
     },
     "expand-tilde": {
       "version": "2.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
@@ -2763,7 +2771,7 @@
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -2811,7 +2819,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -2820,7 +2828,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -2860,13 +2868,13 @@
     },
     "fast-deep-equal": {
       "version": "2.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
@@ -2877,9 +2885,9 @@
       "dev": true
     },
     "figures": {
-      "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/figures/-/figures-3.0.0.tgz",
-      "integrity": "sha1-dWJ1yWRkYWPMb5GXx6ApXb/QTek=",
+      "version": "3.1.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/figures/-/figures-3.1.0.tgz",
+      "integrity": "sha1-SxmN0H2NcVMGQoZK8tRd2eRZxOw=",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -2887,7 +2895,7 @@
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
@@ -2899,7 +2907,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -2952,13 +2960,13 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -2967,7 +2975,7 @@
     },
     "from2": {
       "version": "2.3.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/from2/-/from2-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
@@ -2986,7 +2994,7 @@
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
@@ -2998,7 +3006,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -3639,13 +3647,13 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "github-url-from-git": {
       "version": "1.5.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
       "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
       "dev": true
     },
@@ -3665,7 +3673,7 @@
     },
     "glob-parent": {
       "version": "3.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/glob-parent/-/glob-parent-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
@@ -3675,7 +3683,7 @@
       "dependencies": {
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
@@ -3685,12 +3693,12 @@
       }
     },
     "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "version": "2.0.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/global-dirs/-/global-dirs-2.0.1.tgz",
+      "integrity": "sha1-rN87tmhbzVXLNeigUiZlaelGkgE=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "^1.3.5"
       }
     },
     "global-modules": {
@@ -3712,12 +3720,21 @@
             "kind-of": "^6.0.2",
             "which": "^1.3.1"
           }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/which/-/which-1.3.1.tgz",
+          "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
     "global-prefix": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/global-prefix/-/global-prefix-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
@@ -3726,6 +3743,17 @@
         "ini": "^1.3.4",
         "is-windows": "^1.0.1",
         "which": "^1.2.14"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/which/-/which-1.3.1.tgz",
+          "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "globals": {
@@ -3736,7 +3764,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/globby/-/globby-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -3749,7 +3777,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -3793,7 +3821,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -3802,7 +3830,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         }
@@ -3810,19 +3838,19 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "version": "1.0.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
       "dev": true
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -3833,7 +3861,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -3843,7 +3871,7 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -3860,7 +3888,7 @@
     },
     "hash-base": {
       "version": "3.0.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/hash-base/-/hash-base-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
@@ -3880,7 +3908,7 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
@@ -3899,9 +3927,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/hosted-git-info/-/hosted-git-info-3.0.0.tgz",
-      "integrity": "sha1-3Yr0nNAec8yOYboT4hencv1OzS0=",
+      "version": "3.0.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/hosted-git-info/-/hosted-git-info-3.0.2.tgz",
+      "integrity": "sha1-i3470RS1m1F4b4ut4POd3IAnWpc=",
       "dev": true,
       "requires": {
         "lru-cache": "^5.1.1"
@@ -3915,8 +3943,14 @@
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/https-browserify/-/https-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+      "dev": true
+    },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha1-xbHNFPUK6uCatsWf5jujOV/k36M=",
       "dev": true
     },
     "iconv-lite": {
@@ -3936,13 +3970,13 @@
     },
     "iferr": {
       "version": "0.1.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/iferr/-/iferr-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
     "import-fresh": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/import-fresh/-/import-fresh-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "requires": {
@@ -3952,7 +3986,7 @@
     },
     "import-lazy": {
       "version": "2.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/import-lazy/-/import-lazy-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true
     },
@@ -3968,13 +4002,13 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent-string": {
       "version": "3.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/indent-string/-/indent-string-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
@@ -3986,7 +4020,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -4027,6 +4061,128 @@
         "through": "^2.3.6"
       }
     },
+    "inquirer-autosubmit-prompt": {
+      "version": "0.2.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/inquirer-autosubmit-prompt/-/inquirer-autosubmit-prompt-0.2.0.tgz",
+      "integrity": "sha1-oQ+VKvT3usnEMBDj6eCJHX6NFaE=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "inquirer": "^6.2.1",
+        "rxjs": "^6.3.3"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "inquirer": {
+          "version": "6.5.2",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/inquirer/-/inquirer-6.5.2.tgz",
+          "integrity": "sha1-rVCUI3XQNtMn/1KMCL1fqwiZKMo=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.12",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
     "interpret": {
       "version": "1.2.0",
       "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/interpret/-/interpret-1.2.0.tgz",
@@ -4056,7 +4212,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -4065,7 +4221,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -4076,13 +4232,13 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
@@ -4106,7 +4262,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -4115,7 +4271,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -4145,19 +4301,19 @@
     },
     "is-directory": {
       "version": "0.3.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-directory/-/is-directory-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
@@ -4177,13 +4333,21 @@
       }
     },
     "is-installed-globally": {
-      "version": "0.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-installed-globally/-/is-installed-globally-0.2.0.tgz",
-      "integrity": "sha1-jN4HreUIRYtR8UvNoxX/r0iY3jA=",
+      "version": "0.3.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-installed-globally/-/is-installed-globally-0.3.1.tgz",
+      "integrity": "sha1-Z5r++Bk0enJYRhf9GUl/AQuO018=",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.1",
-        "is-path-inside": "^2.1.0"
+        "global-dirs": "^2.0.1",
+        "is-path-inside": "^3.0.1"
+      },
+      "dependencies": {
+        "is-path-inside": {
+          "version": "3.0.2",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-path-inside/-/is-path-inside-3.0.2.tgz",
+          "integrity": "sha1-9SIPyCo+IzdXKR3dycWHfyofMBc=",
+          "dev": true
+        }
       }
     },
     "is-npm": {
@@ -4194,7 +4358,7 @@
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
@@ -4203,7 +4367,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -4214,7 +4378,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -4253,7 +4417,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
@@ -4268,7 +4432,7 @@
     },
     "is-promise": {
       "version": "2.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-promise/-/is-promise-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
@@ -4304,7 +4468,7 @@
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
@@ -4316,19 +4480,19 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
@@ -4389,7 +4553,7 @@
     },
     "json-buffer": {
       "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/json-buffer/-/json-buffer-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
@@ -4406,9 +4570,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/json5/-/json5-2.1.0.tgz",
-      "integrity": "sha1-56DGLEgoXGKNIKELhcibuAfDKFA=",
+      "version": "2.1.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/json5/-/json5-2.1.1.tgz",
+      "integrity": "sha1-gbbLBOm6SW8ccAXQe0NoomOPkLY=",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -4449,7 +4613,7 @@
     },
     "lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
@@ -4472,168 +4636,27 @@
       "dependencies": {
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-stream/-/is-stream-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         }
       }
     },
     "listr-input": {
-      "version": "0.1.3",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/listr-input/-/listr-input-0.1.3.tgz",
-      "integrity": "sha1-DDE5Z7bReevpZKgek2POKlo50lw=",
+      "version": "0.2.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/listr-input/-/listr-input-0.2.0.tgz",
+      "integrity": "sha1-OgOJePoUozktzN2kNYd3+XD+JMc=",
       "dev": true,
       "requires": {
-        "inquirer": "^3.3.0",
-        "rxjs": "^5.5.2",
+        "inquirer": "^7.0.0",
+        "inquirer-autosubmit-prompt": "^0.2.0",
+        "rxjs": "^6.5.3",
         "through": "^2.3.8"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "3.2.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-          "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "chardet": {
-          "version": "0.4.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/chardet/-/chardet-0.4.2.tgz",
-          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-          "dev": true
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
-        "external-editor": {
-          "version": "2.2.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/external-editor/-/external-editor-2.2.0.tgz",
-          "integrity": "sha1-BFURz9jRM/OEZnPRBHwVTiFK09U=",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.4.0",
-            "iconv-lite": "^0.4.17",
-            "tmp": "^0.0.33"
-          }
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "inquirer": {
-          "version": "3.3.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.0.4",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rx-lite": "^4.0.8",
-            "rx-lite-aggregates": "^4.0.8",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
-          "dev": true
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "rxjs": {
-          "version": "5.5.12",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/rxjs/-/rxjs-5.5.12.tgz",
-          "integrity": "sha1-b6YbinfD15PbrycL7i9D9lLXQcw=",
-          "dev": true,
-          "requires": {
-            "symbol-observable": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "symbol-observable": {
-          "version": "1.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/symbol-observable/-/symbol-observable-1.0.1.tgz",
-          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-          "dev": true
-        }
       }
     },
     "listr-silent-renderer": {
       "version": "1.1.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
       "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
       "dev": true
     },
@@ -4655,19 +4678,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4680,7 +4703,7 @@
         },
         "figures": {
           "version": "1.7.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/figures/-/figures-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
@@ -4690,7 +4713,7 @@
         },
         "log-symbols": {
           "version": "1.0.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/log-symbols/-/log-symbols-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
@@ -4699,7 +4722,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -4708,7 +4731,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -4728,7 +4751,7 @@
       "dependencies": {
         "cli-cursor": {
           "version": "2.1.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
@@ -4737,7 +4760,7 @@
         },
         "figures": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/figures/-/figures-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
@@ -4752,7 +4775,7 @@
         },
         "onetime": {
           "version": "2.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/onetime/-/onetime-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
@@ -4761,7 +4784,7 @@
         },
         "restore-cursor": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
@@ -4773,7 +4796,7 @@
     },
     "load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
@@ -4785,7 +4808,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -4837,7 +4860,7 @@
     },
     "lodash.zip": {
       "version": "4.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
       "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
       "dev": true
     },
@@ -4852,7 +4875,7 @@
     },
     "log-update": {
       "version": "2.3.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/log-update/-/log-update-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
       "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "dev": true,
       "requires": {
@@ -4869,7 +4892,7 @@
         },
         "cli-cursor": {
           "version": "2.1.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
@@ -4884,7 +4907,7 @@
         },
         "onetime": {
           "version": "2.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/onetime/-/onetime-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
@@ -4893,7 +4916,7 @@
         },
         "restore-cursor": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
@@ -4914,7 +4937,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -4964,19 +4987,19 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-obj": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/map-obj/-/map-obj-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -5007,7 +5030,7 @@
     },
     "memory-fs": {
       "version": "0.4.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/memory-fs/-/memory-fs-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
@@ -5034,7 +5057,7 @@
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -5043,7 +5066,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
@@ -5062,7 +5085,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
@@ -5071,13 +5094,13 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "read-pkg-up": {
           "version": "3.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
@@ -5144,7 +5167,7 @@
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
@@ -5159,7 +5182,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -5258,7 +5281,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -5267,7 +5290,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -5275,7 +5298,7 @@
     },
     "move-concurrently": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
@@ -5370,19 +5393,27 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
       }
     },
     "node-releases": {
-      "version": "1.1.32",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/node-releases/-/node-releases-1.1.32.tgz",
-      "integrity": "sha1-SFs1wb+bTYuqEF14L4ynMeUYJ24=",
+      "version": "1.1.42",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/node-releases/-/node-releases-1.1.42.tgz",
+      "integrity": "sha1-qZn2pi+HRpgfbakGJ6jS/AkLutc=",
       "dev": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
       }
     },
     "normalize-package-data": {
@@ -5398,9 +5429,9 @@
       },
       "dependencies": {
         "hosted-git-info": {
-          "version": "2.8.4",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-          "integrity": "sha1-RBGauvS8ZGkqFqzjRwD+2cA+JUY=",
+          "version": "2.8.5",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+          "integrity": "sha1-dZz88sTRVq3lmwst+r3cQqa5xww=",
           "dev": true
         }
       }
@@ -5412,44 +5443,44 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.3.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/normalize-url/-/normalize-url-4.3.0.tgz",
-      "integrity": "sha1-nEnhD8GHaut226iL8bK12fpXsu4=",
+      "version": "4.5.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha1-RTNUCH5sqWlXvY9br3U/WYIUISk=",
       "dev": true
     },
     "np": {
-      "version": "5.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/np/-/np-5.1.0.tgz",
-      "integrity": "sha1-5iXCx9rhWcQdKm7QRRyTC+4L2Os=",
+      "version": "5.2.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/np/-/np-5.2.1.tgz",
+      "integrity": "sha1-A3vEGmcC+iDsAC/CTzbr6qKzGKI=",
       "dev": true,
       "requires": {
         "@samverschueren/stream-to-observable": "^0.3.0",
-        "any-observable": "^0.4.0",
+        "any-observable": "^0.5.0",
         "async-exit-hook": "^2.0.1",
-        "chalk": "^2.3.0",
+        "chalk": "^3.0.0",
         "cosmiconfig": "^5.2.1",
         "del": "^4.1.0",
         "escape-string-regexp": "^2.0.0",
-        "execa": "^2.0.1",
+        "execa": "^3.4.0",
         "github-url-from-git": "^1.5.0",
         "has-yarn": "^2.1.0",
         "hosted-git-info": "^3.0.0",
         "inquirer": "^7.0.0",
-        "is-installed-globally": "^0.2.0",
+        "is-installed-globally": "^0.3.1",
         "is-scoped": "^2.1.0",
         "issue-regex": "^2.0.0",
         "listr": "^0.14.3",
-        "listr-input": "^0.1.3",
+        "listr-input": "^0.2.0",
         "log-symbols": "^3.0.0",
         "meow": "^5.0.0",
         "npm-name": "^5.4.0",
         "onetime": "^5.1.0",
-        "open": "^6.1.0",
-        "ow": "^0.13.2",
+        "open": "^7.0.0",
+        "ow": "^0.15.0",
         "p-memoize": "^3.1.0",
         "p-timeout": "^3.1.0",
         "pkg-dir": "^4.1.0",
-        "read-pkg-up": "^6.0.0",
+        "read-pkg-up": "^7.0.0",
         "rxjs": "^6.3.3",
         "semver": "^6.1.2",
         "split": "^1.0.0",
@@ -5458,6 +5489,41 @@
         "update-notifier": "^3.0.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-styles/-/ansi-styles-4.2.0.tgz",
+          "integrity": "sha1-VoHw3PeuWICnhB2IMcRyTtnMAXI=",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
         "escape-string-regexp": {
           "version": "2.0.0",
           "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
@@ -5473,6 +5539,12 @@
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
           }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
@@ -5512,6 +5584,15 @@
           "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -5531,37 +5612,29 @@
       }
     },
     "npm-run-path": {
-      "version": "3.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/npm-run-path/-/npm-run-path-3.1.0.tgz",
-      "integrity": "sha1-f5G+MX9qRm7+08nymArYpO6LD6U=",
+      "version": "4.0.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/npm-run-path/-/npm-run-path-4.0.0.tgz",
+      "integrity": "sha1-1kTsG9BWkYfSpSkJlxAjoKWOhDg=",
       "dev": true,
       "requires": {
         "path-key": "^3.0.0"
-      },
-      "dependencies": {
-        "path-key": {
-          "version": "3.1.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-key/-/path-key-3.1.0.tgz",
-          "integrity": "sha1-maENhwqAO91e5vBHDljfzS+aVNM=",
-          "dev": true
-        }
       }
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -5572,7 +5645,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -5581,7 +5654,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -5598,7 +5671,7 @@
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -5619,7 +5692,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
@@ -5628,7 +5701,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -5645,17 +5718,25 @@
       }
     },
     "open": {
-      "version": "6.4.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/open/-/open-6.4.0.tgz",
-      "integrity": "sha1-XBPpbQ3IlGhhZPGJZez+iJ7PyKk=",
+      "version": "7.0.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/open/-/open-7.0.0.tgz",
+      "integrity": "sha1-flKZmxTrc/kPDwgH/pOJfErnPsk=",
       "dev": true,
       "requires": {
-        "is-wsl": "^1.1.0"
+        "is-wsl": "^2.1.0"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "2.1.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-wsl/-/is-wsl-2.1.1.tgz",
+          "integrity": "sha1-ShwVLUKd89RBZpSY4khtNZbrrx0=",
+          "dev": true
+        }
       }
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/os-browserify/-/os-browserify-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
@@ -5670,6 +5751,19 @@
         "mem": "^4.0.0"
       },
       "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
         "execa": {
           "version": "1.0.0",
           "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/execa/-/execa-1.0.0.tgz",
@@ -5696,13 +5790,13 @@
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-stream/-/is-stream-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
@@ -5711,25 +5805,55 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/p-finally/-/p-finally-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/which/-/which-1.3.1.tgz",
+          "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "ow": {
-      "version": "0.13.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ow/-/ow-0.13.2.tgz",
-      "integrity": "sha1-N15209P5KKjfzwzQuckhy2LkaaA=",
+      "version": "0.15.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ow/-/ow-0.15.0.tgz",
+      "integrity": "sha1-DZKARpiUItewbw1vIAFwFqA3PfU=",
       "dev": true,
       "requires": {
-        "type-fest": "^0.5.1"
+        "type-fest": "^0.8.1"
       }
     },
     "p-cancelable": {
@@ -5740,7 +5864,7 @@
     },
     "p-defer": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/p-defer/-/p-defer-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true
     },
@@ -5791,9 +5915,9 @@
       }
     },
     "p-timeout": {
-      "version": "3.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/p-timeout/-/p-timeout-3.1.0.tgz",
-      "integrity": "sha1-GYwfUDu5c+m5cnF3onbICv1oUfM=",
+      "version": "3.2.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
       "dev": true,
       "requires": {
         "p-finally": "^1.0.0"
@@ -5801,7 +5925,7 @@
       "dependencies": {
         "p-finally": {
           "version": "1.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/p-finally/-/p-finally-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         }
@@ -5851,9 +5975,9 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/parse-asn1/-/parse-asn1-5.1.4.tgz",
-      "integrity": "sha1-N/Zij4I/vesic7TVQENKIvPvH8w=",
+      "version": "5.1.5",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/parse-asn1/-/parse-asn1-5.1.5.tgz",
+      "integrity": "sha1-ADJxND2ljclMrOSU+u89IUfs6g4=",
       "dev": true,
       "requires": {
         "asn1.js": "^4.0.0",
@@ -5866,7 +5990,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
@@ -5876,13 +6000,13 @@
     },
     "parse-passwd": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
@@ -5894,32 +6018,32 @@
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "version": "3.1.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "dev": true
     },
     "path-parse": {
@@ -5939,7 +6063,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -5966,13 +6090,13 @@
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -5990,13 +6114,13 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
     "prepend-http": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/prepend-http/-/prepend-http-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
@@ -6008,7 +6132,7 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
@@ -6020,19 +6144,19 @@
     },
     "promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
     "prr": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/prr/-/prr-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
@@ -6091,19 +6215,19 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "quick-lru": {
       "version": "1.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/quick-lru/-/quick-lru-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
@@ -6140,7 +6264,7 @@
     },
     "read-pkg": {
       "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/read-pkg/-/read-pkg-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
@@ -6150,14 +6274,14 @@
       }
     },
     "read-pkg-up": {
-      "version": "6.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/read-pkg-up/-/read-pkg-up-6.0.0.tgz",
-      "integrity": "sha1-2nXOcnYvL6HyDFpA1N2Ax325aeM=",
+      "version": "7.0.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha1-86YTV1hFlzOuK5VjgFbhhU5+9Qc=",
       "dev": true,
       "requires": {
-        "find-up": "^4.0.0",
-        "read-pkg": "^5.1.1",
-        "type-fest": "^0.5.0"
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
       },
       "dependencies": {
         "find-up": {
@@ -6256,7 +6380,7 @@
     },
     "redent": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/redent/-/redent-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "dev": true,
       "requires": {
@@ -6304,12 +6428,6 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "regexp-tree": {
-      "version": "0.1.13",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/regexp-tree/-/regexp-tree-0.1.13.tgz",
-      "integrity": "sha1-Wxmrk3ftxovDZ5JWhAuymvwVjX8=",
-      "dev": true
-    },
     "regexpu-core": {
       "version": "4.6.0",
       "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/regexpu-core/-/regexpu-core-4.6.0.tgz",
@@ -6344,9 +6462,9 @@
       }
     },
     "regjsgen": {
-      "version": "0.5.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/regjsgen/-/regjsgen-0.5.0.tgz",
-      "integrity": "sha1-p2NNwI+JIJwgSa3aNSVxH7lyZd0=",
+      "version": "0.5.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/regjsgen/-/regjsgen-0.5.1.tgz",
+      "integrity": "sha1-SPC/Gl6iBRlpKcDZeYtC0e2YRDw=",
       "dev": true
     },
     "regjsparser": {
@@ -6360,7 +6478,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -6368,7 +6486,7 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
@@ -6380,13 +6498,13 @@
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
@@ -6397,9 +6515,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
+      "version": "1.13.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/resolve/-/resolve-1.13.1.tgz",
+      "integrity": "sha1-vgqkwGrNUwg1BauzX01mkyqzXRY=",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -6407,7 +6525,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -6416,7 +6534,7 @@
     },
     "resolve-dir": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
@@ -6439,19 +6557,19 @@
     },
     "resolve-from": {
       "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/resolve-from/-/resolve-from-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "responselike": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/responselike/-/responselike-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
@@ -6495,7 +6613,7 @@
     },
     "run-async": {
       "version": "2.3.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/run-async/-/run-async-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
@@ -6504,26 +6622,11 @@
     },
     "run-queue": {
       "version": "1.0.3",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/run-queue/-/run-queue-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
         "aproba": "^1.1.1"
-      }
-    },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
-      "requires": {
-        "rx-lite": "*"
       }
     },
     "rxjs": {
@@ -6543,7 +6646,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -6581,22 +6684,16 @@
     },
     "semver-diff": {
       "version": "2.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/semver-diff/-/semver-diff-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
         "semver": "^5.0.3"
       }
     },
-    "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
-      "dev": true
-    },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
@@ -6614,7 +6711,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -6625,7 +6722,7 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
@@ -6640,29 +6737,29 @@
       }
     },
     "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "version": "2.0.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "version": "3.0.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
@@ -6693,7 +6790,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -6702,7 +6799,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -6711,7 +6808,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -6730,7 +6827,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -6779,7 +6876,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -6796,7 +6893,7 @@
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
@@ -6833,7 +6930,7 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
@@ -6889,23 +6986,22 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "ssri": {
-      "version": "7.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ssri/-/ssri-7.1.0.tgz",
-      "integrity": "sha1-ksJBv23oI2W1x/tL126XVSLhKU0=",
+      "version": "6.0.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ssri/-/ssri-6.0.1.tgz",
+      "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
       "dev": true,
       "requires": {
-        "figgy-pudding": "^3.5.1",
-        "minipass": "^3.1.1"
+        "figgy-pudding": "^3.5.1"
       }
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -6915,7 +7011,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -6959,19 +7055,30 @@
     },
     "stream-shift": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/stream-shift/-/stream-shift-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
     "string-width": {
-      "version": "4.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/string-width/-/string-width-4.1.0.tgz",
-      "integrity": "sha1-uoRtHaqXw8WWFVMIBj4HXtHJmv8=",
+      "version": "4.2.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
       "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^5.2.0"
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "string_decoder": {
@@ -6990,17 +7097,25 @@
       "dev": true,
       "requires": {
         "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "dev": true
+        }
       }
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -7012,13 +7127,13 @@
     },
     "strip-indent": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-indent/-/strip-indent-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
@@ -7048,9 +7163,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/supports-color/-/supports-color-7.0.0.tgz",
-          "integrity": "sha1-8jksUKs1uzyue+6/JNJUoZ+IDAY=",
+          "version": "7.1.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -7072,7 +7187,7 @@
     },
     "term-size": {
       "version": "1.2.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/term-size/-/term-size-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
@@ -7081,7 +7196,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
@@ -7092,7 +7207,7 @@
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/execa/-/execa-0.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
@@ -7107,13 +7222,13 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-stream/-/is-stream-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
@@ -7129,7 +7244,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
@@ -7138,13 +7253,43 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/p-finally/-/p-finally-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/which/-/which-1.3.1.tgz",
+          "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -7180,25 +7325,51 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "2.2.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/terser-webpack-plugin/-/terser-webpack-plugin-2.2.2.tgz",
-      "integrity": "sha1-Km4AI3ElVkpFWtabIuCO5ZQgRzo=",
+      "version": "2.3.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/terser-webpack-plugin/-/terser-webpack-plugin-2.3.0.tgz",
+      "integrity": "sha1-AP2PeSozDcVy4uK0aP18tf/X6lE=",
       "dev": true,
       "requires": {
         "cacache": "^13.0.1",
         "find-cache-dir": "^3.1.0",
         "jest-worker": "^24.9.0",
         "schema-utils": "^2.6.1",
-        "serialize-javascript": "^2.1.1",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.4.2",
         "webpack-sources": "^1.4.3"
       },
       "dependencies": {
+        "cacache": {
+          "version": "13.0.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cacache/-/cacache-13.0.1.tgz",
+          "integrity": "sha1-qAAMIWlwiQgvhSh6GuxuOCAkpxw=",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.2",
+            "figgy-pudding": "^3.5.1",
+            "fs-minipass": "^2.0.0",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.2",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^5.1.1",
+            "minipass": "^3.0.0",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "p-map": "^3.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.7.1",
+            "ssri": "^7.0.0",
+            "unique-filename": "^1.1.1"
+          }
+        },
         "find-cache-dir": {
-          "version": "3.1.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/find-cache-dir/-/find-cache-dir-3.1.0.tgz",
-          "integrity": "sha1-mTWJSZnevvTPn2d/32RtACxM3ss=",
+          "version": "3.2.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+          "integrity": "sha1-5/5EwavBKZ9RYUblYxCP0QBsGHQ=",
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
@@ -7243,6 +7414,15 @@
             "p-limit": "^2.2.0"
           }
         },
+        "p-map": {
+          "version": "3.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/p-map/-/p-map-3.0.0.tgz",
+          "integrity": "sha1-1wTZr4orpoTiYA2aIVmD1BQal50=",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-exists/-/path-exists-4.0.0.tgz",
@@ -7274,11 +7454,27 @@
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         },
+        "serialize-javascript": {
+          "version": "2.1.2",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+          "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
+        },
+        "ssri": {
+          "version": "7.1.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ssri/-/ssri-7.1.0.tgz",
+          "integrity": "sha1-ksJBv23oI2W1x/tL126XVSLhKU0=",
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "minipass": "^3.1.1"
+          }
         }
       }
     },
@@ -7290,7 +7486,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -7314,9 +7510,9 @@
       }
     },
     "tlds": {
-      "version": "1.203.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/tlds/-/tlds-1.203.1.tgz",
-      "integrity": "sha1-TcmwL1PeMxW8mLgGZeE94+38Hfw=",
+      "version": "1.207.0",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/tlds/-/tlds-1.207.0.tgz",
+      "integrity": "sha1-RZJk5kTPY93All/s44mJEyhrGv0=",
       "dev": true
     },
     "tmp": {
@@ -7330,19 +7526,19 @@
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -7351,7 +7547,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -7380,7 +7576,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
@@ -7390,14 +7586,8 @@
     },
     "trim-newlines": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
       "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-      "dev": true
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
     "tslib": {
@@ -7408,19 +7598,19 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "type-fest": {
-      "version": "0.5.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/type-fest/-/type-fest-0.5.2.tgz",
-      "integrity": "sha1-1u9CoDVsbNRfSUhcO2KB/BSOSKI=",
+      "version": "0.8.1",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
       "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
@@ -7484,7 +7674,7 @@
     },
     "unique-string": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/unique-string/-/unique-string-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
@@ -7493,7 +7683,7 @@
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -7503,7 +7693,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -7514,7 +7704,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -7525,7 +7715,7 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
@@ -7557,9 +7747,18 @@
         "xdg-basedir": "^3.0.0"
       },
       "dependencies": {
+        "global-dirs": {
+          "version": "0.1.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/global-dirs/-/global-dirs-0.1.1.tgz",
+          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+          "dev": true,
+          "requires": {
+            "ini": "^1.3.4"
+          }
+        },
         "is-installed-globally": {
           "version": "0.1.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
           "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "dev": true,
           "requires": {
@@ -7569,7 +7768,7 @@
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "dev": true,
           "requires": {
@@ -7589,13 +7788,13 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/url/-/url-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "requires": {
@@ -7605,7 +7804,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -7613,7 +7812,7 @@
     },
     "url-parse-lax": {
       "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "dev": true,
       "requires": {
@@ -7647,7 +7846,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         }
@@ -7655,7 +7854,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
@@ -7677,7 +7876,7 @@
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
@@ -7685,9 +7884,9 @@
       }
     },
     "vm-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/vm-browserify/-/vm-browserify-1.1.0.tgz",
-      "integrity": "sha1-vXbWojMj4sqP+hICjcBFWcdfkBk=",
+      "version": "1.1.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA=",
       "dev": true
     },
     "watchpack": {
@@ -7702,9 +7901,9 @@
       }
     },
     "webpack": {
-      "version": "4.40.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/webpack/-/webpack-4.40.2.tgz",
-      "integrity": "sha1-0hQz0lD5AL8PrLq+j1DVhbLcMKc=",
+      "version": "4.41.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/webpack/-/webpack-4.41.2.tgz",
+      "integrity": "sha1-w07Hbao6hGjJthpQM22OMwPc504=",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -7732,28 +7931,11 @@
         "webpack-sources": "^1.4.1"
       },
       "dependencies": {
-        "cacache": {
-          "version": "12.0.3",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cacache/-/cacache-12.0.3.tgz",
-          "integrity": "sha1-vpmruk4b9d9GHNWiwQcfxDJXM5A=",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.5.5",
-            "chownr": "^1.1.1",
-            "figgy-pudding": "^3.5.1",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.1.15",
-            "infer-owner": "^1.0.3",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.3",
-            "ssri": "^6.0.1",
-            "unique-filename": "^1.1.1",
-            "y18n": "^4.0.0"
-          }
+        "serialize-javascript": {
+          "version": "2.1.2",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+          "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
@@ -7761,26 +7943,17 @@
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
-        "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
-          "dev": true,
-          "requires": {
-            "figgy-pudding": "^3.5.1"
-          }
-        },
         "terser-webpack-plugin": {
-          "version": "1.4.2",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/terser-webpack-plugin/-/terser-webpack-plugin-1.4.2.tgz",
-          "integrity": "sha1-4jwNVUWH0fRzvQz2hidyDnM4kKQ=",
+          "version": "1.4.3",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+          "integrity": "sha1-Xsry29xfuZdF/QZ5H0b8ndscmnw=",
           "dev": true,
           "requires": {
             "cacache": "^12.0.2",
             "find-cache-dir": "^2.1.0",
             "is-wsl": "^1.1.0",
             "schema-utils": "^1.0.0",
-            "serialize-javascript": "^2.1.1",
+            "serialize-javascript": "^2.1.2",
             "source-map": "^0.6.1",
             "terser": "^4.1.2",
             "webpack-sources": "^1.4.0",
@@ -7790,9 +7963,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.9",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/webpack-cli/-/webpack-cli-3.3.9.tgz",
-      "integrity": "sha1-ecJ+cflLf+Mk1ZSrZKjjlrnaqRo=",
+      "version": "3.3.10",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/webpack-cli/-/webpack-cli-3.3.10.tgz",
+      "integrity": "sha1-F7J5Jn6bT7VJAj+uFw2o5udm2hM=",
       "dev": true,
       "requires": {
         "chalk": "2.4.2",
@@ -7808,6 +7981,51 @@
         "yargs": "13.2.4"
       },
       "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "4.1.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+          "integrity": "sha1-Qcfgv9/nSsH/4eV61qXGyfN0Kn8=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.4.0",
+            "tapable": "^1.0.0"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/supports-color/-/supports-color-6.1.0.tgz",
@@ -7815,6 +8033,15 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/which/-/which-1.3.1.tgz",
+          "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -7838,9 +8065,9 @@
       }
     },
     "which": {
-      "version": "1.3.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/which/-/which-1.3.1.tgz",
-      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "version": "2.0.2",
+      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/which/-/which-2.0.2.tgz",
+      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -7848,7 +8075,7 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
@@ -7863,13 +8090,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -7885,7 +8112,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -7905,7 +8132,7 @@
     },
     "wrap-ansi": {
       "version": "3.0.1",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
       "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
       "dev": true,
       "requires": {
@@ -7915,13 +8142,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -7937,7 +8164,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -7948,7 +8175,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -7965,7 +8192,7 @@
     },
     "xdg-basedir": {
       "version": "3.0.0",
-      "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
@@ -8020,7 +8247,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://repo.onegini.com/artifactory/api/npm/public-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "clean-webpack-plugin": "^3.0.0",
     "np": "^5.1.0",
     "text-encoding": "^0.7.0",
-    "uglifyjs-webpack-plugin": "^2.2.0",
+    "terser-webpack-plugin": "^2.2.0",
     "webpack": "^4.40.2",
     "webpack-cli": "^3.3.9"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = {
   mode: "production",
@@ -45,12 +45,8 @@ if (process.env.NODE_ENV === 'production') {
 
   module.exports.optimization = {
     minimizer: [
-      new UglifyJsPlugin({
-        sourceMap: true,
-        uglifyOptions: {
-          warnings: false,
-          compress: {}
-        },
+      new TerserPlugin({
+        sourceMap: true
       }),
     ]
   }


### PR DESCRIPTION
The UglifyJS Webpack plugin is deprecated and a big source of vulnerability alerts.

This switches UglifyJS to Terser, which is its recommended replacement.