### PR TITLE
Allow disabling error wrapping in fetch method

### DIFF
--- a/src/js/onegini.js
+++ b/src/js/onegini.js
@@ -36,7 +36,7 @@ module.exports = (function () {
 
     callbackResult = utils.callbackExec('OneginiClient', 'start', [], function (config) {
           if (options.secureXhr === true) {
-            resource.init(config.resourceBaseURL);
+            resource.init(config.resourceBaseURL,  config.disableErrorHandling);
           }
           successCb();
         },

--- a/src/js/resource.js
+++ b/src/js/resource.js
@@ -56,6 +56,7 @@ module.exports = (function (XMLHttpRequest, TextDecoder, CustomEvent) {
   };
 
   let resourceBaseUrl;
+  let errorHandlingDisabled;
 
   if (!TextDecoder) {
     TextDecoder = require('text-encoding').TextDecoder;
@@ -94,7 +95,7 @@ module.exports = (function (XMLHttpRequest, TextDecoder, CustomEvent) {
       }
     }
 
-    utils.callbackExec('OneginiResourceClient', 'fetch', options, success, failure);
+    utils.callbackExec('OneginiResourceClient', 'fetch', options, success, errorHandlingDisabled ? success : failure);
 
     if (successCb) {
       return;
@@ -171,9 +172,10 @@ module.exports = (function (XMLHttpRequest, TextDecoder, CustomEvent) {
     return result;
   }
 
-  function init(url) {
+  function init(url, disableErrorHandling = false) {
     window.XMLHttpRequest = OneginiXMLHttpRequest;
     resourceBaseUrl = url;
+    errorHandlingDisabled = disableErrorHandling;
   }
 
   function disable() {


### PR DESCRIPTION
When the client app needs to handle http responses with status code >=400 but also wants to use `secureXhr=true` they need this option.